### PR TITLE
:art: 유저 닉네임, 직업 받아오기

### DIFF
--- a/feature/mypage/src/main/java/com/example/mypage/MyPageApp.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/MyPageApp.kt
@@ -69,7 +69,15 @@ fun MyPageApp(
                 )
             }
         }
-        composable("account") { AccountSettingScreen(navController = navController) }
+        composable("account") {
+            ui.userInfo?.let { user ->
+                AccountSettingScreen(
+                    navController = navController,
+                    nicknamePlaceholder = user.nickname,
+                    jobPlaceholder = user.jobName
+                )
+            }
+        }
         composable("alarm") { AlarmSettingScreen(navController = navController) }
         composable("quit") {
             ServiceQuitScreen(

--- a/feature/mypage/src/main/java/com/example/mypage/screen/AccountSettingScreen.kt
+++ b/feature/mypage/src/main/java/com/example/mypage/screen/AccountSettingScreen.kt
@@ -57,12 +57,13 @@ import com.example.mypage.R
 
 @Composable
 fun AccountSettingScreen(
-    navController: NavController
+    navController: NavController,
+    nicknamePlaceholder: String,
+    jobPlaceholder: String
 ) {
-    val username = "세나"  // TODO: 추후 수정
-    val userjob = "대학생"
-    var name by remember { mutableStateOf("") }
-    var job by remember { mutableStateOf(userjob) }
+    val username = nicknamePlaceholder
+    val userjob  = jobPlaceholder
+    var name by remember(nicknamePlaceholder) { mutableStateOf("") }
 
     val purposeTagRows = listOf(
         listOf("업무자료 아카이빙", "인사이트 모으기"),
@@ -85,10 +86,15 @@ fun AccountSettingScreen(
 
     // 드롭다운 옵션 (직업 목록)
     val jobOptions = listOf("고등학생", "대학생", "직장인", "자영업자", "프리랜서", "취준생")
-    var selectedJob by remember { mutableStateOf(jobOptions[1]) } // "대학생"으로 초기화
+    var selectedJob by remember(jobPlaceholder) {
+        mutableStateOf(
+            jobPlaceholder.takeIf { it.isNotBlank() } ?: jobOptions.first()
+        )
+    }
 
     // 변경 사항이 있는지 여부 확인
-    val isModified = name != "" && name != username || job != "" && job != userjob
+    val isModified =
+        (name.isNotBlank() && name != username) || (selectedJob != userjob)
 
     // 비활성화용 그라데이션 브러시
     val inactiveBrush = Brush.horizontalGradient(
@@ -524,5 +530,9 @@ fun BrushText(
 @Composable
 fun PreviewAccountSettingScreen() {
     val navController = rememberNavController()
-    AccountSettingScreen(navController = navController)
+    AccountSettingScreen(
+        navController = navController,
+        nicknamePlaceholder = "세나",
+        jobPlaceholder = "대학생"
+    )
 }


### PR DESCRIPTION
## 📝 설명
> 해당 PR이 진행한 사항을 자세히 적어주세요.

마이페이지 계정 수정 페이지에서 유저 닉네임과 직업을 받아와 보여주게 변경하였습니다.

## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [X] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> 해당 PR과 관련된 이슈 번호를 적어주세요.

#27 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * 계정 설정 화면에서 사용자 닉네임·직업이 플레이스홀더로 표시되어 진입 즉시 확인·수정 가능.
  * 플레이스홀더 변경 시 입력란과 직업 선택이 해당 값으로 자동 초기화되어 일관된 상태 유지.
* Bug Fixes
  * 사용자 정보가 없을 때 계정 설정 화면을 표시하지 않아 빈값 노출 및 오류 가능성을 예방, 안정성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->