### PR TITLE
🔥 공유 폴더 내에서 링크 삭제 가능 & 링크 추가하기 보이는 오류 수정

### DIFF
--- a/feature/file/src/main/java/com/example/file/ui/content/LinksGrid.kt
+++ b/feature/file/src/main/java/com/example/file/ui/content/LinksGrid.kt
@@ -53,6 +53,8 @@ fun LinksGrid(
 
     var onLinkLongClick: () -> Unit = {}
 
+    val isShareMode = folderStateViewModel.isSharedFolders
+
     VerticalGrid(
         modifier = Modifier
             .fillMaxWidth(),
@@ -60,64 +62,58 @@ fun LinksGrid(
         horizontalArrangement = Arrangement.spacedBy(9.dp),
         verticalArrangement = Arrangement.spacedBy(18.51.dp),
     ) {
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .noRippleClickable {
-                    Log.d("LinksGrid", "링크 추가하기 클릭")
-                    if (hasNotCategorizationLinks) {
-                        folderStateViewModel.updateLinkCategorizationBottomSheetVisible(true)
-                    } else {
-                        categorizationModalWindowVisible = true
-                    }
-                },
-            contentAlignment = Alignment.TopStart
-        ) {
+        if(!isShareMode){
             Box(
-                modifier = Modifier,
-                contentAlignment = Alignment.TopCenter
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .noRippleClickable {
+                        Log.d("LinksGrid", "링크 추가하기 클릭")
+                        if (hasNotCategorizationLinks) {
+                            folderStateViewModel.updateLinkCategorizationBottomSheetVisible(true)
+                        } else {
+                            categorizationModalWindowVisible = true
+                        }
+                    },
+                contentAlignment = Alignment.TopStart
             ) {
                 Box(
-                    modifier = Modifier.alpha(1f),
+                    modifier = Modifier,
+                    contentAlignment = Alignment.TopCenter
                 ) {
-                    LinkItemLayout(
-                        link = null
+                    Box(
+                        modifier = Modifier.alpha(1f),
+                    ) {
+                        LinkItemLayout(
+                            link = null
+                        )
+                    }
+
+                    Image(
+                        modifier = Modifier.padding(top = 103.dp),
+                        painter = painterResource(R.drawable.add_folder_icon),
+                        contentDescription = null
+                    )
+
+                    Text(
+                        modifier = Modifier.padding(top = 147.dp),
+                        text = "링크 추가하기",
+                        fontSize = 15.sp,
+                        fontFamily = DefaultFont,
+                        fontWeight = FontWeight(500),
+                        color = Black,
+                        textAlign = TextAlign.Center,
                     )
                 }
-
-                Image(
-                    modifier = Modifier.padding(top = 103.dp),
-                    painter = painterResource(R.drawable.add_folder_icon),
-                    contentDescription = null
-                )
-
-                Text(
-                    modifier = Modifier.padding(top = 147.dp),
-                    text = "링크 추가하기",
-                    fontSize = 15.sp,
-                    fontFamily = DefaultFont,
-                    fontWeight = FontWeight(500),
-                    color = Black,
-                    textAlign = TextAlign.Center,
-                )
             }
         }
 
-        val scope = rememberCoroutineScope()
-
         // items 람다 안에 folder를 넘겨줘야 FolderItemLayout에서 사용할 수 있어!
         for((i, link) in linkList.withIndex()) {
-            onLinkLongClick = {
-                link.linkuId.let {
-                    Log.d("LinkItemLayout", "아이템 롱클릭: \"savelinkresult/${link.linkuId}\"")
-                    fileViewModel.deleteLink(link.linkuId)
-                }
-            }
 
             Box(
                 modifier = Modifier
                     .fillMaxWidth(),
-                contentAlignment = if(i%2==1) Alignment.TopStart else Alignment.TopEnd
+                contentAlignment = if((i%2==1) xor isShareMode) Alignment.TopStart else Alignment.TopEnd
             ) {
                 LinkItemLayout(
                     link = link,
@@ -125,7 +121,19 @@ fun LinksGrid(
                         fileViewModel.onLinkClick?.invoke(link.linkuId)
                     },
                     onLongClick = {
-                        deleteModalWindowVisible = true
+                        if(!isShareMode){
+                            onLinkLongClick = {
+                                link.linkuId.let {
+                                    Log.d(
+                                        "LinkItemLayout",
+                                        "아이템 롱클릭: \"savelinkresult/${link.linkuId}\""
+                                    )
+                                    fileViewModel.deleteLink(link.linkuId)
+                                }
+                            }
+
+                            deleteModalWindowVisible = true
+                        }
                     }
                 )
             }


### PR DESCRIPTION
## 📝 설명
> 해당 PR이 진행한 사항을 자세히 적어주세요.


## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> 해당 PR과 관련된 이슈 번호를 적어주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 공유 모드를 반영해 UI 동작을 분기: 공유 모드에서는 “링크 추가하기”가 숨겨지고 길게 누르기 삭제가 비활성화됩니다.
- UX/UI
  - 아이템 정렬 규칙을 조정해 그리드 배치를 개선했습니다.
  - 삭제 동작을 모달 확인 흐름으로 통합(비공유 모드에서만)하여 실수 삭제를 줄였습니다.
  - 추가 카드(“링크 추가하기”)의 시각적 표현을 유지하며 내부 구성을 정돈했습니다.
- 리팩터링
  - 불필요한 코루틴 스코프 제거 및 내부 레이아웃 구조 정리.
  - 디버깅을 위한 로그 유지.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->