### PR TITLE
♻️ refactor(feature/141): `Purpose`, `Interest` 열거형의 `serverKey` 관리 방식 및 조회 …

### DIFF
--- a/core/src/main/java/com/linku/core/model/auth/Interest.kt
+++ b/core/src/main/java/com/linku/core/model/auth/Interest.kt
@@ -3,27 +3,28 @@ package com.linku.core.model.auth
 
 enum class Interest(
     override val displayName: String,
-    override val serverKey: String
 ) : SelectionItem {
     // 행 1
-    BUSINESS("비즈니스\n& 마케팅", "BUSINESS"),
-    STARTUP("스타트업\n& 창업", "STARTUP"),
-    INSIGHTS("책 요약\n& 인사이트", "INSIGHTS"),
+    BUSINESS("비즈니스\n& 마케팅"),
+    STARTUP("스타트업\n& 창업"),
+    INSIGHTS("책 요약\n& 인사이트"),
 
     // 행 2
-    DESIGN("디자인\n& 크리에이티브", "DESIGN"),
-    CURRENT_EVENTS("시사\n& 트렌드", "CURRENT_EVENTS"),
-    STUDY("학습 & 리포트\n참고 자료", "STUDY"),
+    DESIGN("디자인\n& 크리에이티브"),
+    CURRENT_EVENTS("시사\n& 트렌드"),
+    STUDY("학습 & 리포트\n참고 자료"),
 
     // 행 3
-    IT("IT\n& 개발", "IT"),
-    CAREER("커리어\n& 채용", "CAREER"),
-    COLLECT("그냥\n모아두고 싶은 글", "COLLECT"),
+    IT("IT\n& 개발"),
+    CAREER("커리어\n& 채용"),
+    COLLECT("그냥\n모아두고 싶은 글"),
 
     // 행 4
-    SOCIETY("사회 & 문화\n& 환경", "SOCIETY"),
-    WRITING("글쓰기\n& 콘텐츠 노하우", "WRITING"),
-    PSYCHOLOGY("심리\n& 자기계발", "PSYCHOLOGY");
+    SOCIETY("사회 & 문화\n& 환경"),
+    WRITING("글쓰기\n& 콘텐츠 노하우"),
+    PSYCHOLOGY("심리\n& 자기계발");
+
+    override val serverKey: String get() = name
 
     companion object {
         fun fromServerKey(key: String): Interest? = selectionItemOfServerKey(key)

--- a/core/src/main/java/com/linku/core/model/auth/Purpose.kt
+++ b/core/src/main/java/com/linku/core/model/auth/Purpose.kt
@@ -1,25 +1,26 @@
 package com.linku.core.model.auth
 
 
-enum  class Purpose(
+enum class Purpose(
     override val displayName: String,
-    override val serverKey: String
 ) : SelectionItem{
     // 행 1
-    CAREER("취업\n& 커리어 준비", "CAREER"),
-    CREATION_REFERENCE("글쓰기 \n& 콘텐츠 제작", "CREATION_REFERENCE"),
-    INSIGHTS("인사이트\n모으기", "INSIGHTS"),
+    CAREER("취업\n& 커리어 준비"),
+    CREATION_REFERENCE("글쓰기 \n& 콘텐츠 제작"),
+    INSIGHTS("인사이트\n모으기"),
 
     // 행 2
-    SIDE_PROJECT("사이드 프로젝트\n& 창업", "SIDE_PROJECT"),
-    STUDY("학업\n& 리포트 정리", "STUDY"),
-    LATER_READING("나중에\n읽고 싶은 글", "LATER_READING"),
+    SIDE_PROJECT("사이드 프로젝트\n& 창업"),
+    STUDY("학업\n& 리포트 정리"),
+    LATER_READING("나중에\n읽고 싶은 글"),
 
     // 행 3
-    SELF_DEVELOPMENT("자기계발\n& 정보 수집", "SELF_DEVELOPMENT"),
-    WORK("업무자료\n아카이빙", "WORK"),
+    SELF_DEVELOPMENT("자기계발\n& 정보 수집"),
+    WORK("업무자료\n아카이빙"),
 
-    OTHERS("기타", "OTHERS");
+    OTHERS("기타");
+
+    override val serverKey: String get() = name
 
     companion object {
         fun fromServerKey(key: String): Purpose? = selectionItemOfServerKey(key)

--- a/core/src/main/java/com/linku/core/model/auth/SelectionItem.kt
+++ b/core/src/main/java/com/linku/core/model/auth/SelectionItem.kt
@@ -7,7 +7,7 @@ interface SelectionItem {
 
 inline fun <reified T> selectionItemOfServerKey(serverKey: String): T?
         where T : Enum<T>, T : SelectionItem {
-    return enumValues<T>().firstOrNull { it.serverKey == serverKey }
+    return runCatching { enumValueOf<T>(serverKey) }.getOrNull()
 }
 
 inline fun <reified T> selectionItemOfDisplayName(displayName: String): T?

--- a/core/src/main/java/com/linku/core/model/auth/SelectionItem.kt
+++ b/core/src/main/java/com/linku/core/model/auth/SelectionItem.kt
@@ -7,7 +7,7 @@ interface SelectionItem {
 
 inline fun <reified T> selectionItemOfServerKey(serverKey: String): T?
         where T : Enum<T>, T : SelectionItem {
-    return runCatching { enumValueOf<T>(serverKey) }.getOrNull()
+    return enumValues<T>().firstOrNull { it.serverKey == serverKey }
 }
 
 inline fun <reified T> selectionItemOfDisplayName(displayName: String): T?


### PR DESCRIPTION
📝 설명

Interest, Purpose 열거형의 serverKey가 enum 상수 이름(name)과 항상 동일한데도 생성자 파라미터로 중복 입력되고 있던 부분을 정리. serverKey를 name에 위임하여 중복 타이핑 및 오타 가능성을 제거하고, 조회 유틸리티도 enumValueOf 기반으로 변경해 성능과 안정성을 개선함.

## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> #141 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 개선 사항

* **리팩토링**
  * 내부 모델 구조를 최적화하여 시스템 유지보수성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->