### PR TITLE
🪲 fix(backup): 백업 및 데이터 추출 규칙에서 인증 정보 제외

### DIFF
--- a/app/src/main/res/xml/backup_rules.xml
+++ b/app/src/main/res/xml/backup_rules.xml
@@ -10,4 +10,6 @@
    <include domain="sharedpref" path="."/>
    <exclude domain="sharedpref" path="device.xml"/>
 -->
+    <!-- 리프레시 토큰 등 인증 정보가 백업에 포함되면 앱 삭제 후 재설치해도 자동 로그인되는 버그 발생 -->
+    <exclude domain="file" path="datastore/auth_prefs.preferences_pb"/>
 </full-backup-content>

--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -9,6 +9,8 @@
         <include .../>
         <exclude .../>
         -->
+        <!-- 리프레시 토큰 등 인증 정보가 클라우드 백업에 포함되면 앱 삭제 후 재설치해도 자동 로그인되는 버그 발생 -->
+        <exclude domain="file" path="datastore/auth_prefs.preferences_pb"/>
     </cloud-backup>
     <!--
     <device-transfer>


### PR DESCRIPTION
## 📝 설명
- `data_extraction_rules.xml`의 클라우드 백업 대상에서 `auth_prefs` DataStore 파일 제외
- `backup_rules.xml`의 전체 백업 대상에서 `auth_prefs` DataStore 파일 제외
- 앱 삭제 후 재설치 시 인증 정보(리프레시 토큰 등)가 복원되어 자동 로그인되는 현상 방지.

## ✔️ PR 유형
위와 동일함

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> #151 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 앱 삭제 후 재설치했을 때 이전 로그인 상태가 그대로 복원될 수 있는 문제를 방지했습니다.
  * 백업 대상에서 인증 관련 정보를 제외해, 원치 않는 자동 로그인을 막았습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->