### PR TITLE
🚑️ hotfix(ui): 그리드 아이템 레이아웃 구조 단순화 및 비율 수정

### DIFF
--- a/feature/file/src/main/java/com/linku/file/ui/content/ClassifiedLinksGrid.kt
+++ b/feature/file/src/main/java/com/linku/file/ui/content/ClassifiedLinksGrid.kt
@@ -6,11 +6,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
@@ -123,7 +121,7 @@ internal fun ClassifiedLinksGrid(
                 AddLinkItem(
                     modifier = Modifier
                         // 실제 링크 카드와 동일한 셀 점유율을 사용해 그리드 정렬을 맞춥니다.
-                        .fillMaxSize(164f / 174f)
+                        .fillMaxSize()
                         .noRippleClickable {
                             Log.d("LinksGrid", "링크 추가하기 클릭")
                             // 미분류 링크가 있으면 분류 바텀시트를 열고, 없으면 안내 모달을 띄웁니다.
@@ -139,7 +137,7 @@ internal fun ClassifiedLinksGrid(
             /** 분류된 링크 목록을 링크 카드 레이아웃으로 렌더링합니다. */
             items(links, key = {it.linkuId}) { link ->
                 LinkItemLayout(
-                    modifier = Modifier.fillMaxSize(164f / 174f),
+                    modifier = Modifier.fillMaxSize(),
                     link = link,
                     onClick = {
                         // 상세 화면 이동은 상위에서 전달받은 링크 클릭 콜백으로 위임합니다.
@@ -216,41 +214,36 @@ private fun AddLinkItem(
     /** 링크 추가 아이템의 라벨 색상을 가져오기 위한 테마 색상입니다. */
     val colors = MaterialTheme.linkuColors
 
-    /** 카드 폭은 상위 modifier가 결정하고, Row는 그리드 셀 안에서 가로 기준선을 맞춥니다. */
-    Row(
-        modifier = Modifier.fillMaxWidth(),
+    /** 빈 링크 카드 위에 아이콘과 텍스트를 겹쳐 올리는 오버레이 컨테이너입니다. */
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.TopCenter
     ) {
-        /** 빈 링크 카드 위에 아이콘과 텍스트를 겹쳐 올리는 오버레이 컨테이너입니다. */
+        /** 실제 링크 카드와 같은 형태의 placeholder를 배경으로 사용합니다. */
         Box(
-            modifier = modifier,
-            contentAlignment = Alignment.TopCenter
+            modifier = Modifier.alpha(1f),
         ) {
-            /** 실제 링크 카드와 같은 형태의 placeholder를 배경으로 사용합니다. */
-            Box(
-                modifier = Modifier.alpha(1f),
-            ) {
-                LinkItemLayout(
-                    link = null
-                )
-            }
-
-            /** 링크 추가를 나타내는 아이콘을 카드 상단 기준 위치에 배치합니다. */
-            Image(
-                modifier = Modifier.padding(top = 103.dp),
-                painter = painterResource(R.drawable.add_folder_icon),
-                contentDescription = null
-            )
-
-            /** 추가 아이콘 아래에 표시되는 링크 추가 라벨입니다. */
-            Text(
-                modifier = Modifier.padding(top = 147.dp),
-                text = "링크 추가하기",
-                fontSize = 15.sp,
-                fontWeight = FontWeight(500),
-                color = colors.black,
-                textAlign = TextAlign.Center,
+            LinkItemLayout(
+                link = null
             )
         }
+
+        /** 링크 추가를 나타내는 아이콘을 카드 상단 기준 위치에 배치합니다. */
+        Image(
+            modifier = Modifier.padding(top = 103.dp),
+            painter = painterResource(R.drawable.add_folder_icon),
+            contentDescription = null
+        )
+
+        /** 추가 아이콘 아래에 표시되는 링크 추가 라벨입니다. */
+        Text(
+            modifier = Modifier.padding(top = 147.dp),
+            text = "링크 추가하기",
+            fontSize = 15.sp,
+            fontWeight = FontWeight(500),
+            color = colors.black,
+            textAlign = TextAlign.Center,
+        )
     }
 }
 

--- a/feature/file/src/main/java/com/linku/file/ui/content/MyFoldersGrid.kt
+++ b/feature/file/src/main/java/com/linku/file/ui/content/MyFoldersGrid.kt
@@ -8,11 +8,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.calculateEndPadding
 import androidx.compose.foundation.layout.calculateStartPadding
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.GridItemSpan
@@ -149,7 +147,7 @@ internal fun MyFoldersGrid(
                 AddBottomFolderItem(
                     modifier = Modifier
                         // 실제 폴더 카드와 동일한 셀 점유율을 사용해 그리드 정렬을 맞춥니다.
-                        .fillMaxSize(164f / 174f)
+                        .fillMaxSize()
                         .noRippleClickable {
                             // 편집 모드에서는 카드 내부 편집 액션과 충돌하지 않도록 추가 동작을 막습니다.
                             if (!isEditMode) {
@@ -162,6 +160,7 @@ internal fun MyFoldersGrid(
             /** 선택된 최상위 폴더에 속한 하위 폴더 목록을 렌더링합니다. */
             items(folders, key = {it.folderId}) { folder ->
                 MyFolderItem(
+                    modifier = Modifier.fillMaxSize(),
                     folder = folder,
                     colorStyle = selectedTopFolderColorStyle,
                     isEditMode = isEditMode,
@@ -204,7 +203,7 @@ internal fun MyFoldersGrid(
                 /** 미분류 링크 목록을 폴더 카드 다음 셀부터 이어서 배치합니다. */
                 items(notCategorizationLinks, key = {it.linkuId}) { link ->
                     LinkItemLayout(
-                        modifier = Modifier.fillMaxSize(164f / 174f),
+                        modifier = Modifier.fillMaxSize(),
                         link = link,
                         onClick = {
                             // 미분류 링크도 일반 링크와 동일하게 상세 화면 이동 콜백으로 위임합니다.
@@ -264,34 +263,29 @@ private fun AddBottomFolderItem(
     /** 폴더 추가 아이템의 라벨 색상을 가져오기 위한 테마 색상입니다. */
     val colors = MaterialTheme.linkuColors
 
-    /** 카드 폭은 상위 modifier가 결정하고, Row는 그리드 셀 안에서 가로 기준선을 맞춥니다. */
-    Row(
-        modifier = Modifier.fillMaxWidth()
+    /** 빈 폴더 카드 위에 아이콘과 텍스트를 겹쳐 올리는 오버레이 컨테이너입니다. */
+    Box(
+        modifier = modifier,
+        contentAlignment = Alignment.Center
     ) {
-        /** 빈 폴더 카드 위에 아이콘과 텍스트를 겹쳐 올리는 오버레이 컨테이너입니다. */
-        Box(
-            modifier = modifier,
-            contentAlignment = Alignment.Center
-        ) {
-            /** 실제 폴더 카드와 같은 형태의 placeholder를 배경으로 사용합니다. */
-            EmptyFolderItemLayout()
+        /** 실제 폴더 카드와 같은 형태의 placeholder를 배경으로 사용합니다. */
+        EmptyFolderItemLayout()
 
-            /** 폴더 추가를 나타내는 아이콘을 카드 중앙 기준 위치에 배치합니다. */
-            Image(
-                modifier = Modifier.padding(top = 71.dp),
-                painter = painterResource(R.drawable.add_folder_icon),
-                contentDescription = null
-            )
+        /** 폴더 추가를 나타내는 아이콘을 카드 중앙 기준 위치에 배치합니다. */
+        Image(
+            modifier = Modifier.padding(top = 71.dp),
+            painter = painterResource(R.drawable.add_folder_icon),
+            contentDescription = null
+        )
 
-            /** 추가 아이콘과 함께 표시되는 폴더 추가 라벨입니다. */
-            Text(
-                text = "폴더 추가하기",
-                fontSize = 15.sp,
-                fontWeight = FontWeight(500),
-                color = colors.black,
-                textAlign = TextAlign.Center,
-            )
-        }
+        /** 추가 아이콘과 함께 표시되는 폴더 추가 라벨입니다. */
+        Text(
+            text = "폴더 추가하기",
+            fontSize = 15.sp,
+            fontWeight = FontWeight(500),
+            color = colors.black,
+            textAlign = TextAlign.Center,
+        )
     }
 }
 
@@ -312,6 +306,7 @@ private fun AddBottomFolderItem(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun MyFolderItem(
+    modifier: Modifier,
     folder: FolderSimpleInfo,
     colorStyle: CategoryColorStyle,
     isEditMode: Boolean,
@@ -329,8 +324,8 @@ private fun MyFolderItem(
     /** 하위 폴더를 길게 눌렀을 때 표시되는 삭제 확인 모달 상태입니다. */
     var deleteModalWindowVisible by remember { mutableStateOf(false) }
 
-    /** 카드 전체에 일반 클릭과 long click을 함께 연결하는 터치 영역입니다. */
-    Box(
+    /** 실제 폴더 카드 UI는 공통 카드 레이아웃 컴포저블에 위임합니다. */
+    MyFolderItemLayout(
         modifier = Modifier.combinedClickable(
             indication = null,
             interactionSource = interactionSource,
@@ -345,18 +340,13 @@ private fun MyFolderItem(
                 deleteModalWindowVisible = true
             }
         ),
-        contentAlignment = Alignment.Center
-    ) {
-        /** 실제 폴더 카드 UI는 공통 카드 레이아웃 컴포저블에 위임합니다. */
-        MyFolderItemLayout(
-            modifier = Modifier.fillMaxSize(164f / 174f),
-            colorStyle = colorStyle,
-            folder = folder,
-            isEditMode = isEditMode,
-            onEdit = onEdit,
-            onChangeSharing = onChangeSharing
-        )
-    }
+        colorStyle = colorStyle,
+        folder = folder,
+        isEditMode = isEditMode,
+        onEdit = onEdit,
+        onChangeSharing = onChangeSharing
+    )
+
 
     // 하위 폴더 long click 이후 실제 삭제를 한 번 더 확인하는 모달창입니다.
     ModalWindow(


### PR DESCRIPTION
## 📝 설명
그리드 아이템의 카드 크기 계산이 하드코딩된 비율에 의존하지 않도록 수정했습니다.

`ClassifiedLinksGrid`와 `MyFoldersGrid`에서 링크/폴더/추가 아이템이 그리드 셀 전체를 안정적으로 사용하도록 `fillMaxSize()` 기반으로 정리하고, 불필요한 레이아웃 래퍼를 제거해 일부 화면에서 발생할 수 있는 카드 정렬 및 여백 어긋남 가능성을 줄였습니다.

## 🔧 주요 변경 사항
- `ClassifiedLinksGrid`, `MyFoldersGrid`의 링크/폴더/추가 아이템에서 `fillMaxSize(164f / 174f)`를 `fillMaxSize()`로 변경
- `AddLinkItem`, `AddBottomFolderItem`의 불필요한 `Row` 래퍼 제거
- 추가 아이템을 `Box` 오버레이 구조로 단순화하여 placeholder, icon, label 배치 안정화
- `MyFolderItem`에 `modifier` 파라미터를 추가하여 외부에서 카드 크기를 제어할 수 있도록 개선
- `MyFolderItem` 내부의 중첩 `Box`를 제거하고 `MyFolderItemLayout`에 `combinedClickable`을 직접 적용하도록 구조 변경

## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📁 변경 파일
- `feature/file/src/main/java/com/linku/file/ui/content/ClassifiedLinksGrid.kt`
- `feature/file/src/main/java/com/linku/file/ui/content/MyFoldersGrid.kt`

## ✅ 확인 사항
- 그리드 아이템이 셀 크기를 기준으로 동일하게 배치되도록 수정했습니다.
- 링크/폴더 추가 카드의 내부 레이아웃 계층을 줄여 UI 구조를 단순화했습니다.
- 하위 폴더 카드의 클릭/롱클릭 동작은 유지하면서 터치 영역 적용 구조를 정리했습니다.