### PR TITLE
Feature/#171 : 리마인드 화면(#44-1) 및 그라데이션 원 고정 배경 구현

### DIFF
--- a/feature/curation/build.gradle.kts
+++ b/feature/curation/build.gradle.kts
@@ -87,4 +87,8 @@ dependencies {
     implementation(libs.coil.svg)
 
     implementation(libs.accompanist.systemuicontroller)
+
+    // paging
+    implementation(libs.paging.runtime)
+    implementation(libs.paging.compose)
 }

--- a/feature/curation/src/main/java/com/linku/curation/CurationGraph.kt
+++ b/feature/curation/src/main/java/com/linku/curation/CurationGraph.kt
@@ -26,8 +26,8 @@ fun NavGraphBuilder.curationGraph(
             CurationScreen(
                 nickname = nickname,
                 viewModel = curationViewModel,
-                onCard1Click = { navigator.navigate("curation_card1") },
-                onCard3Click = { navigator.navigate("curation_card3") },
+                onMonthlyDetailClick = { navigator.navigate("curation_card1") },
+                onRemindClick = { navigator.navigate("curation_card3") },
                 onMonthlyCurationClick = { navigator.navigate("curation_monthly") }
             )
         }

--- a/feature/curation/src/main/java/com/linku/curation/CurationViewModel.kt
+++ b/feature/curation/src/main/java/com/linku/curation/CurationViewModel.kt
@@ -1,14 +1,42 @@
 package com.linku.curation
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.paging.Pager
+import androidx.paging.PagingConfig
+import androidx.paging.PagingData
+import androidx.paging.cachedIn
+import com.linku.core.model.LinkSimpleInfo
+import com.linku.curation.paging.RemindLinkPagingSource
 import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
+private const val REMIND_LINK_PAGE_SIZE = 10
 
 @HiltViewModel
 class CurationViewModel @Inject constructor(
 
 ) : ViewModel() {
+
+    /**
+     * "저장만 하고 열어보지 않은 링크" 목록(#44-1).
+     *
+     * TODO: CurationApi/CurationRepository(princeHw 작업)가 준비되면
+     * [RemindLinkPagingSource]를 실제 네트워크 PagingSource로 교체.
+     *
+     * Paging3는 기본적으로 첫 로드 시 pageSize의 3배를 한 번에 불러오는데, => 현우 공주님께서 알려주심
+     * 10개 단위로 화면을 구성하기 위해 [PagingConfig.initialLoadSize]를
+     * pageSize와 동일하게 강제 고정함.
+     */
+    val remindLinks: Flow<PagingData<LinkSimpleInfo>> = Pager(
+        config = PagingConfig(
+            pageSize = REMIND_LINK_PAGE_SIZE,
+            initialLoadSize = REMIND_LINK_PAGE_SIZE, // 여기 고정 안하면 30개 나옴.
+            enablePlaceholders = false // 아직 불러오지 않은 자리 null로 채우지 않게 설정함.
+        ),
+        pagingSourceFactory = { RemindLinkPagingSource() } // 바로 넘기지 않고 람다로 감싸서 필요할 때마다 만드는 방법을 알려줌
+    ).flow.cachedIn(viewModelScope) // flow는 콜드 스트림이라 구독할 때마다 데이터를 만드는데 이를 cachedIn(viewModelScope)를 통해 방지함. 뷰모델이 살아 있는 동안 유지함.
 }
 
 

--- a/feature/curation/src/main/java/com/linku/curation/paging/RemindLinkPagingSource.kt
+++ b/feature/curation/src/main/java/com/linku/curation/paging/RemindLinkPagingSource.kt
@@ -5,6 +5,7 @@ import androidx.paging.PagingState
 import com.linku.core.model.CategoryType
 import com.linku.core.model.EmotionType
 import com.linku.core.model.LinkSimpleInfo
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.delay
 
 /**
@@ -52,6 +53,10 @@ internal class RemindLinkPagingSource : PagingSource<Int, LinkSimpleInfo>() {
                 prevKey = if (page == 0) null else page - 1, // 0페이지면 이전 페이지가 없음
                 nextKey = nextKey
             )
+        } catch (e: CancellationException) {
+            // 코루틴 취소는 정상적인 흐름이라 Error로 감싸면 안 되고 그대로 다시 던져야 함
+            // (delay(300)이 진짜 suspension point라 화면 이탈 등으로 실제 취소될 수 있음)
+            throw e
         } catch (e: Exception) {
             // 지금은 더미 생성이라 실질적으로 예외가 안 나지만, 실제 API 호출로 바뀌면
             // 네트워크 실패 시 여기로 들어와서 LazyPagingItems.loadState가 Error로 바뀜

--- a/feature/curation/src/main/java/com/linku/curation/paging/RemindLinkPagingSource.kt
+++ b/feature/curation/src/main/java/com/linku/curation/paging/RemindLinkPagingSource.kt
@@ -1,0 +1,133 @@
+package com.linku.curation.paging
+
+import androidx.paging.PagingSource
+import androidx.paging.PagingState
+import com.linku.core.model.CategoryType
+import com.linku.core.model.EmotionType
+import com.linku.core.model.LinkSimpleInfo
+import kotlinx.coroutines.delay
+
+/**
+ * "저장만 하고 열어보지 않은 링크" 목록(#44-1)을 흉내 내는 임시 로컬 [PagingSource].
+ *
+ * CurationApi/CurationRepository(princeHw 작업)가 아직 빈 스텁이라, 실제 네트워크 응답 대신
+ * 더미 데이터를 페이지 단위로 생성함. API가 준비되면 이 클래스를 커서/오프셋 기반
+ * 네트워크 [PagingSource]로 교체하면 됨.
+ *
+ * [PagingSource]는 "페이지 단위로 데이터를 어떻게 가져올지"를 Paging3에 알려주는 인터페이스.
+ * 제네릭 두 개(<Key, Value>) 중 Key=Int는 "다음/이전 페이지를 요청할 때 쓰는 값",
+ * Value=LinkSimpleInfo는 "한 페이지에 담기는 아이템 하나의 타입"을 뜻함.
+ */
+internal class RemindLinkPagingSource : PagingSource<Int, LinkSimpleInfo>() {
+
+    /**
+     * Paging3가 "새 페이지가 필요하다"고 판단할 때마다(최초 로드 포함) 호출하는 함수.
+     *
+     * params.key: 직전 load() 호출이 돌려준 nextKey/prevKey 값. 최초 호출 땐 null.
+     * params.loadSize: 이번에 몇 개를 가져와야 하는지. Pager의 pageSize/initialLoadSize로 정해짐
+     *                   (CurationViewModel에서 pageSize=initialLoadSize=10으로 고정해둔 값).
+     */
+    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, LinkSimpleInfo> {
+        // 최초 로드는 params.key가 null이라, 0페이지(첫 페이지)로 간주
+        val page = params.key ?: 0
+
+        return try {
+            delay(300) // TODO: API 연동 시 삭제 — 네트워크 왕복처럼 보이게 하려고 넣은 인위적 지연
+
+            // TODO: API 연동 시 이 두 줄을 실제 API 호출 + 응답 매핑으로 교체
+            // 지금은 "page * loadSize"로 더미 아이템의 시작 id를 정하고, 그 뒤로 loadSize개를 만들어냄
+            // 예) page=0,loadSize=10 -> id 0~9 / page=1,loadSize=10 -> id 10~19
+            val startId = page * params.loadSize
+            val items =
+                (0 until params.loadSize).map { offset -> createDummyItem(id = startId + offset) }
+
+            // TODO: API 연동 시 서버 응답의 "다음 페이지 존재 여부" 필드로 교체
+            // 지금은 지금까지 만든 아이템 수가 더미 총량(TOTAL_MOCK_ITEM_COUNT)을 넘으면 nextKey=null로 끝냄
+            val nextKey = if (startId + items.size >= TOTAL_MOCK_ITEM_COUNT) null else page + 1
+
+            // LoadResult.Page: 이번에 가져온 데이터(data)와 이전/다음 페이지를 요청할 때 쓸 키를 Paging3에 알려줌.
+            // LazyPagingItems는 이 정보를 보고 스크롤이 끝에 닿았을 때 nextKey로 load()를 다시 호출함.
+            LoadResult.Page(
+                data = items,
+                prevKey = if (page == 0) null else page - 1, // 0페이지면 이전 페이지가 없음
+                nextKey = nextKey
+            )
+        } catch (e: Exception) {
+            // 지금은 더미 생성이라 실질적으로 예외가 안 나지만, 실제 API 호출로 바뀌면
+            // 네트워크 실패 시 여기로 들어와서 LazyPagingItems.loadState가 Error로 바뀜
+            LoadResult.Error(e)
+        }
+    }
+
+    /**
+     * 화면 회전/프로세스 재생성 등으로 Paging3가 데이터를 다시 불러와야 할 때,
+     * "어느 페이지부터 다시 불러올지" 계산하는 함수. Paging3 공식 문서 예시와 동일한 구현이라
+     * API 연동 이후에도 그대로 둬도 됨(더미 데이터 전용 코드가 아님).
+     */
+    override fun getRefreshKey(state: PagingState<Int, LinkSimpleInfo>): Int? {
+        return state.anchorPosition?.let { anchorPosition ->
+            // anchorPosition(사용자가 마지막으로 보고 있던 아이템 위치)이 속한 페이지를 찾고
+            val anchorPage = state.closestPageToPosition(anchorPosition)
+            // 그 페이지의 prevKey+1 (또는 nextKey-1)이 곧 "그 페이지 자신의 키"가 됨
+            anchorPage?.prevKey?.plus(1) ?: anchorPage?.nextKey?.minus(1)
+        }
+    }
+
+    // TODO: API 연동 시 이 함수 전체 삭제 — DTO -> LinkSimpleInfo 매핑은 Repository/Mapper 레이어로 이동
+    private fun createDummyItem(id: Int): LinkSimpleInfo {
+        val sample = DUMMY_SAMPLES[id % DUMMY_SAMPLES.size] // 샘플 5개를 순서대로 돌려가며 재사용(id % 5)
+        return LinkSimpleInfo(
+            linkuId = id.toLong(),
+            categoryId = sample.categoryId,
+            memo = null,
+            emotionId = sample.emotionId,
+            title = sample.title,
+            domain = sample.domainName,
+            domainImageUrl = null,
+            linkuImageUrl = null,
+            aiArticleExists = false, // TODO: 백엔드에서 실제 값 받기 전까지는 기본 false로 고정
+        )
+    }
+
+    // TODO: API 연동 시 삭제 — createDummyItem이 LinkSimpleInfo를 만들 때 쓰는 더미 재료 묶음
+    private data class DummySample(
+        val title: String,
+        val categoryId: Long,
+        val emotionId: Long,
+        val domainName: String,
+    )
+
+    // TODO: API 연동 시 이 companion object 전체(더미 상수 + 더미 목록) 삭제
+    private companion object {
+        const val TOTAL_MOCK_ITEM_COUNT = 50 // 더미 데이터 총 개수. 이 개수를 넘기면 nextKey=null이 되어 스크롤이 멈춤
+
+        // 카드 5종류를 순환시켜서 화면에 다양한 태그/도메인이 섞여 보이게 함
+        val DUMMY_SAMPLES = listOf(
+            DummySample(
+                "오픽 AL 따는 꿀팁 얻고 보러오세요",
+                CategoryType.STUDY_METHOD.id,
+                EmotionType.CALM.value,
+                "BLOG"
+            ),
+            DummySample(
+                "오픽 공부할 때 문법도 공부해야할까?",
+                CategoryType.LANGUAGE.id,
+                EmotionType.EXCITE.value,
+                "GitHub"
+            ),
+            DummySample("필수 영문법", CategoryType.LANGUAGE.id, EmotionType.CALM.value, "네이버쇼핑"),
+            DummySample(
+                "영어회화 배우는 모임",
+                CategoryType.SELF_IMPROVEMENT.id,
+                EmotionType.JOY.value,
+                "네이버쇼핑"
+            ),
+            DummySample(
+                "토익스피킹 VS 오픽 뭐가 더 좋을까?",
+                CategoryType.STUDY_METHOD.id,
+                EmotionType.EXCITE.value,
+                "네이버쇼핑"
+            ),
+        )
+    }
+}

--- a/feature/curation/src/main/java/com/linku/curation/ui/CurationScreen.kt
+++ b/feature/curation/src/main/java/com/linku/curation/ui/CurationScreen.kt
@@ -35,8 +35,8 @@ import com.linku.design.util.scaler
 internal fun CurationScreen(
     nickname: String,
     viewModel: CurationViewModel = hiltViewModel(), //TODO princehw가 구현해줄거임!
-    onCard1Click: () -> Unit = {}, // TODO 다음 PR에서 구현..
-    onCard3Click: () -> Unit = {}, // TODO 다음 PR에서 구현..
+    onMonthlyDetailClick: () -> Unit = {}, // 1번 카드 -> CurationMonthlyDetailScreen
+    onRemindClick: () -> Unit = {}, // 3번 카드 -> CurationRemindScreen
     onMonthlyCurationClick: () -> Unit = {},
 ) {
     val pagerState = rememberPagerState(initialPage = 0, pageCount = { 3 })
@@ -56,9 +56,9 @@ internal fun CurationScreen(
                 pagerState = pagerState,
                 onCardClick = { index, _ ->
                     when (index) {
-                        0 -> onCard1Click()
+                        0 -> onMonthlyDetailClick()
                         1 -> showKeywordDetail = true
-                        2 -> onCard3Click()
+                        2 -> onRemindClick()
                     }
                 },
                 onMonthlyCurationClick = onMonthlyCurationClick

--- a/feature/curation/src/main/java/com/linku/curation/ui/screen/CurationRemindScreen.kt
+++ b/feature/curation/src/main/java/com/linku/curation/ui/screen/CurationRemindScreen.kt
@@ -83,6 +83,8 @@ private fun CurationRemindScreenContent(
                     onBackClick = onBack,
                     contentTopOffset = 105.scaler,
                     title = "${remindMonthText()},\n저장만 하고 열어보지 않은 링크예요",
+                    // TODO: itemCount는 지금까지 페이징으로 불러온 개수라 스크롤할수록 값이 커짐.
+                    // API 연동 후엔 서버가 내려주는 "전체 저장 링크 수" 필드로 교체해야 함(페이징 상태와 무관한 고정값).
                     description = "총 ${remindLinkItems.itemCount}개의 링크가 쌓여있네요!",
                     titleDescriptionGap = 12.scaler,
                 )

--- a/feature/curation/src/main/java/com/linku/curation/ui/screen/CurationRemindScreen.kt
+++ b/feature/curation/src/main/java/com/linku/curation/ui/screen/CurationRemindScreen.kt
@@ -1,16 +1,176 @@
 package com.linku.curation.ui.screen
 
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
+import androidx.paging.LoadState
+import androidx.paging.PagingData
+import androidx.paging.compose.LazyPagingItems
+import androidx.paging.compose.collectAsLazyPagingItems
+import androidx.paging.compose.itemKey
+import com.linku.core.model.CategoryType
+import com.linku.core.model.EmotionType
+import com.linku.core.model.LinkSimpleInfo
+import com.linku.curation.CurationViewModel
+import com.linku.curation.ui.header.CurationTopHeader
+import com.linku.curation.ui.util.CurationGradientCircleBackground
+import com.linku.design.component.LinkCardItem
+import com.linku.design.theme.LinkuPreview
+import com.linku.design.theme.linkuColors
+import com.linku.design.util.scaler
+import kotlinx.coroutines.flow.flowOf
+import java.time.LocalDate
 
-//TODO : 다음 PR에서 구현할거예요....
 @Composable
 fun CurationRemindScreen(
-    onBack: () -> Unit
+    onBack: () -> Unit,
+    viewModel: CurationViewModel = hiltViewModel(),
 ) {
     BackHandler { onBack() }
-    Box(modifier = Modifier.fillMaxSize())
+
+    val remindLinkItems = viewModel.remindLinks.collectAsLazyPagingItems()
+
+    CurationRemindScreenContent(
+        remindLinkItems = remindLinkItems,
+        onBack = onBack,
+    )
+}
+
+/**
+ * "n년 n월"을 오늘로부터 정확히 한 달 전 기준으로 반환. API 없이 고정 문구라 로컬에서 계산.
+ */
+private fun remindMonthText(): String {
+    val lastMonth = LocalDate.now().minusMonths(1)
+    return "${lastMonth.year}년 ${lastMonth.monthValue}월"
+}
+
+@Composable
+private fun CurationRemindScreenContent(
+    remindLinkItems: LazyPagingItems<LinkSimpleInfo>,
+    onBack: () -> Unit,
+) {
+    val isEmpty = remindLinkItems.loadState.refresh is LoadState.NotLoading &&
+            remindLinkItems.itemCount == 0
+
+    CurationGradientCircleBackground {
+        Column(modifier = Modifier.fillMaxWidth()) {
+
+            // 반복이 많기는 한데, 가독성을 위해서...
+            if (isEmpty) {
+                CurationTopHeader(
+                    onBackClick = onBack,
+                    contentTopOffset = 406.scaler,
+                    title = "지난 달 저장한 링크를\n잘 보고 있어요",
+                    description = "저장해둔 링크들을 꾸준히 소비하고 있네요!",
+                    titleDescriptionGap = 12.scaler,
+                )
+            } else {
+                CurationTopHeader(
+                    onBackClick = onBack,
+                    contentTopOffset = 105.scaler,
+                    title = "${remindMonthText()},\n저장만 하고 열어보지 않은 링크예요",
+                    description = "총 ${remindLinkItems.itemCount}개의 링크가 쌓여있네요!",
+                    titleDescriptionGap = 12.scaler,
+                )
+
+                LazyColumn(
+                    modifier = Modifier
+                        .weight(1f)
+                        .fillMaxWidth(),
+                    contentPadding = PaddingValues(
+                        top = 44.scaler,
+                        start = 20.scaler,
+                        end = 20.scaler,
+                        bottom = 20.scaler,
+                    ),
+                    verticalArrangement = Arrangement.spacedBy(10.scaler),
+                ) {
+                    items(
+                        count = remindLinkItems.itemCount,
+                        key = remindLinkItems.itemKey { it.linkuId }
+                    ) { index ->
+                        remindLinkItems[index]?.let { link ->
+                            LinkCardItem(
+                                hasAiSummary = link.aiArticleExists,
+                                linkTitle = link.title,
+                                tags = listOfNotNull(
+                                    link.categoryType?.tagName,
+                                    link.emotionType?.tagName
+                                ),
+                                domainName = link.domain,
+                                isExternalLink = false, // 보통 정해진 도메인일거라 false로 기본값을 둠
+                                linkImageUrl = link.linkuImageUrl ?: "",
+                                domainImageUrl = link.domainImageUrl ?: "",
+                                onDeleteClick = { /* TODO: 삭제 API 연동 전까지는 no-op */ }
+                            )
+                        }
+                    }
+
+                    if (remindLinkItems.loadState.append is LoadState.Loading) {
+                        item {
+                            Box(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .padding(vertical = 16.scaler),
+                                contentAlignment = Alignment.Center
+                            ) {
+                                CircularProgressIndicator(color = MaterialTheme.linkuColors.accentColor)
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Preview(name = "큐레이션 리마인드 (#44-1)", showBackground = true)
+@Composable
+private fun CurationRemindScreenPreview() {
+    val sampleLinks = List(6) { index ->
+        LinkSimpleInfo(
+            linkuId = index.toLong(),
+            categoryId = CategoryType.PRODUCTIVITY_TOOL.id,
+            memo = null,
+            emotionId = EmotionType.CALM.value,
+            title = "오픽 AL 따는 꿀팁 얻고 보러오세요",
+            domain = "BLOG",
+            domainImageUrl = null,
+            linkuImageUrl = null,
+            aiArticleExists = index % 2 == 0,
+        )
+    }
+    val remindLinkItems = flowOf(PagingData.from(sampleLinks)).collectAsLazyPagingItems()
+
+    LinkuPreview {
+        CurationRemindScreenContent(
+            remindLinkItems = remindLinkItems,
+            onBack = {},
+        )
+    }
+}
+
+@Preview(name = "큐레이션 리마인드 - 빈 상태 (#44-1)", showBackground = true)
+@Composable
+private fun CurationRemindScreenEmptyPreview() {
+    val remindLinkItems = flowOf(PagingData.empty<LinkSimpleInfo>()).collectAsLazyPagingItems()
+
+    LinkuPreview {
+        CurationRemindScreenContent(
+            remindLinkItems = remindLinkItems,
+            onBack = {},
+        )
+    }
 }

--- a/feature/curation/src/main/java/com/linku/curation/ui/screen/CurationRemindScreen.kt
+++ b/feature/curation/src/main/java/com/linku/curation/ui/screen/CurationRemindScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -13,6 +14,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
@@ -78,69 +80,79 @@ private fun CurationRemindScreenContent(
     remindLinkItems: LazyPagingItems<LinkSimpleInfo>,
     onBack: () -> Unit,
 ) {
+    val remindMonth = remember { remindMonthText() }
+    val refreshState = remindLinkItems.loadState.refresh
     val isEmpty = remindLinkItems.loadState.refresh is LoadState.NotLoading &&
             remindLinkItems.itemCount == 0
 
     CurationGradientCircleBackground {
-        Column(modifier = Modifier.fillMaxWidth()) {
+        if (refreshState is LoadState.Loading) {
+            Box(
+                modifier = Modifier.fillMaxSize(),
+                contentAlignment = Alignment.Center
+            ) {
+                CircularProgressIndicator(color = MaterialTheme.linkuColors.accentColor)
+            }
+        } else {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                if (isEmpty) {
+                    CurationRemindEmptyHeader(onBack = onBack)
+                } else {
+                    CurationTopHeader(
+                        onBackClick = onBack,
+                        contentTopOffset = 105.scaler,
+                        title = "$remindMonth,\n저장만 하고 열어보지 않은 링크예요",
+                        // TODO: itemCount는 지금까지 페이징으로 불러온 개수라 스크롤할수록 값이 커짐.
+                        // API 연동 후엔 서버가 내려주는 "전체 저장 링크 수" 필드로 교체해야 함(페이징 상태와 무관한 고정값).
+                        description = "총 ${remindLinkItems.itemCount}개의 링크가 쌓여있네요!",
+                        titleDescriptionGap = 12.scaler,
+                    )
 
-            if (isEmpty) {
-                CurationRemindEmptyHeader(onBack = onBack)
-            } else {
-                CurationTopHeader(
-                    onBackClick = onBack,
-                    contentTopOffset = 105.scaler,
-                    title = "${remindMonthText()},\n저장만 하고 열어보지 않은 링크예요",
-                    // TODO: itemCount는 지금까지 페이징으로 불러온 개수라 스크롤할수록 값이 커짐.
-                    // API 연동 후엔 서버가 내려주는 "전체 저장 링크 수" 필드로 교체해야 함(페이징 상태와 무관한 고정값).
-                    description = "총 ${remindLinkItems.itemCount}개의 링크가 쌓여있네요!",
-                    titleDescriptionGap = 12.scaler,
-                )
+                    // 헤더와 리스트 사이 44 간격은 스크롤되지 않는 고정 여백이라 LazyColumn 밖에 둠
+                    Spacer(modifier = Modifier.height(44.scaler))
 
-                // 헤더와 리스트 사이 44 간격은 스크롤되지 않는 고정 여백이라 LazyColumn 밖에 둠
-                Spacer(modifier = Modifier.height(44.scaler))
-
-                LazyColumn(
-                    modifier = Modifier
-                        .weight(1f)
-                        .fillMaxWidth(),
-                    contentPadding = PaddingValues(
-                        start = 20.scaler,
-                        end = 20.scaler,
-                        bottom = 20.scaler,
-                    ),
-                    verticalArrangement = Arrangement.spacedBy(10.scaler),
-                ) {
-                    items(
-                        count = remindLinkItems.itemCount,
-                        key = remindLinkItems.itemKey { it.linkuId }
-                    ) { index ->
-                        remindLinkItems[index]?.let { link ->
-                            LinkCardItem(
-                                hasAiSummary = link.aiArticleExists,
-                                linkTitle = link.title,
-                                tags = listOfNotNull(
-                                    link.categoryType?.tagName,
-                                    link.emotionType?.tagName
-                                ),
-                                domainName = link.domain,
-                                isExternalLink = false, // 보통 정해진 도메인일거라 false로 기본값을 둠
-                                linkImageUrl = link.linkuImageUrl ?: "",
-                                domainImageUrl = link.domainImageUrl ?: "",
-                                onDeleteClick = { /* TODO: 삭제 API 연동 전까지는 no-op */ }
-                            )
+                    LazyColumn(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxWidth(),
+                        contentPadding = PaddingValues(
+                            start = 20.scaler,
+                            end = 20.scaler,
+                            bottom = 20.scaler,
+                        ),
+                        verticalArrangement = Arrangement.spacedBy(10.scaler),
+                    ) {
+                        items(
+                            count = remindLinkItems.itemCount,
+                            key = remindLinkItems.itemKey { it.linkuId }
+                        ) { index ->
+                            remindLinkItems[index]?.let { link ->
+                                LinkCardItem(
+                                    hasAiSummary = link.aiArticleExists,
+                                    linkTitle = link.title,
+                                    tags = listOfNotNull(
+                                        link.categoryType?.tagName,
+                                        link.emotionType?.tagName
+                                    ),
+                                    domainName = link.domain,
+                                    isExternalLink = false, // 보통 정해진 도메인일거라 false로 기본값을 둠
+                                    linkImageUrl = link.linkuImageUrl ?: "",
+                                    domainImageUrl = link.domainImageUrl ?: "",
+                                    onDeleteClick = { /* TODO: 삭제 API 연동 전까지는 no-op */ }
+                                )
+                            }
                         }
-                    }
 
-                    if (remindLinkItems.loadState.append is LoadState.Loading) {
-                        item {
-                            Box(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .padding(vertical = 16.scaler),
-                                contentAlignment = Alignment.Center
-                            ) {
-                                CircularProgressIndicator(color = MaterialTheme.linkuColors.accentColor)
+                        if (remindLinkItems.loadState.append is LoadState.Loading) {
+                            item {
+                                Box(
+                                    modifier = Modifier
+                                        .fillMaxWidth()
+                                        .padding(vertical = 16.scaler),
+                                    contentAlignment = Alignment.Center
+                                ) {
+                                    CircularProgressIndicator(color = MaterialTheme.linkuColors.accentColor)
+                                }
                             }
                         }
                     }

--- a/feature/curation/src/main/java/com/linku/curation/ui/screen/CurationRemindScreen.kt
+++ b/feature/curation/src/main/java/com/linku/curation/ui/screen/CurationRemindScreen.kt
@@ -5,7 +5,9 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.CircularProgressIndicator
@@ -85,12 +87,14 @@ private fun CurationRemindScreenContent(
                     titleDescriptionGap = 12.scaler,
                 )
 
+                // 헤더와 리스트 사이 44 간격은 스크롤되지 않는 고정 여백이라 LazyColumn 밖에 둠
+                Spacer(modifier = Modifier.height(44.scaler))
+
                 LazyColumn(
                     modifier = Modifier
                         .weight(1f)
                         .fillMaxWidth(),
                     contentPadding = PaddingValues(
-                        top = 44.scaler,
                         start = 20.scaler,
                         end = 20.scaler,
                         bottom = 20.scaler,

--- a/feature/curation/src/main/java/com/linku/curation/ui/screen/CurationRemindScreen.kt
+++ b/feature/curation/src/main/java/com/linku/curation/ui/screen/CurationRemindScreen.kt
@@ -58,6 +58,21 @@ private fun remindMonthText(): String {
     return "${lastMonth.year}년 ${lastMonth.monthValue}월"
 }
 
+/**
+ * 링크가 0개일 때 노출되는 헤더. Paging 상태와 무관하게 별도 컴포저블로 분리해서,
+ * 프리뷰에서 [collectAsLazyPagingItems]를 거치지 않고 이 상태를 바로 확인할 수 있게 함.
+ */
+@Composable
+private fun CurationRemindEmptyHeader(onBack: () -> Unit) {
+    CurationTopHeader(
+        onBackClick = onBack,
+        contentTopOffset = 406.scaler,
+        title = "지난 달 저장한 링크를\n잘 보고 있어요",
+        description = "저장해둔 링크들을 꾸준히 소비하고 있네요!",
+        titleDescriptionGap = 12.scaler,
+    )
+}
+
 @Composable
 private fun CurationRemindScreenContent(
     remindLinkItems: LazyPagingItems<LinkSimpleInfo>,
@@ -69,15 +84,8 @@ private fun CurationRemindScreenContent(
     CurationGradientCircleBackground {
         Column(modifier = Modifier.fillMaxWidth()) {
 
-            // 반복이 많기는 한데, 가독성을 위해서...
             if (isEmpty) {
-                CurationTopHeader(
-                    onBackClick = onBack,
-                    contentTopOffset = 406.scaler,
-                    title = "지난 달 저장한 링크를\n잘 보고 있어요",
-                    description = "저장해둔 링크들을 꾸준히 소비하고 있네요!",
-                    titleDescriptionGap = 12.scaler,
-                )
+                CurationRemindEmptyHeader(onBack = onBack)
             } else {
                 CurationTopHeader(
                     onBackClick = onBack,
@@ -168,15 +176,23 @@ private fun CurationRemindScreenPreview() {
     }
 }
 
+/**
+ * 링크가 0개일 때 [CurationTopHeader]가 contentTopOffset = 406.scaler 위치까지
+ * 내려간 채로 단독 노출되는지 확인하기 위한 프리뷰.
+ *
+ * [collectAsLazyPagingItems]는 LaunchedEffect로 비동기 수집되는데, 정적 프리뷰는
+ * 첫 프레임만 캡처해서 그 수집이 끝나기 전(로딩 중) 상태로 고정돼버림 -> isEmpty가 항상
+ * false로 잡혀서 빈 상태 분기를 볼 수 없었음. 그래서 Paging을 아예 거치지 않고
+ * [CurationRemindEmptyHeader]를 직접 그려서 확인함.
+ */
 @Preview(name = "큐레이션 리마인드 - 빈 상태 (#44-1)", showBackground = true)
 @Composable
 private fun CurationRemindScreenEmptyPreview() {
-    val remindLinkItems = flowOf(PagingData.empty<LinkSimpleInfo>()).collectAsLazyPagingItems()
-
     LinkuPreview {
-        CurationRemindScreenContent(
-            remindLinkItems = remindLinkItems,
-            onBack = {},
-        )
+        CurationGradientCircleBackground {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                CurationRemindEmptyHeader(onBack = {})
+            }
+        }
     }
 }

--- a/feature/curation/src/main/java/com/linku/curation/ui/util/CurationGradientCircleBackground.kt
+++ b/feature/curation/src/main/java/com/linku/curation/ui/util/CurationGradientCircleBackground.kt
@@ -1,0 +1,62 @@
+package com.linku.curation.ui.util
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxScope
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.offset
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import com.linku.curation.ui.effect.highlight.RadialGradientCircle
+import com.linku.design.theme.LinkuPreview
+import com.linku.design.theme.linkuColors
+import com.linku.design.util.scaler
+
+/**
+ * 스크롤되는 화면 컨텐츠 뒤에 고정되는 핑크·파랑 그라데이션 원 배경 (#44-1-1).
+ *
+ * 스크롤 컨테이너를 [content]에 넣으면, 원은 스크롤 대상이 아니라서
+ * 화면을 내려도 계속 같은 자리에 고정된 채로 보임.
+ *
+ * @param content 배경 위에 그릴 스크롤 컨텐츠.
+ */
+@Composable
+internal fun CurationGradientCircleBackground(
+    modifier: Modifier = Modifier,
+    content: @Composable BoxScope.() -> Unit = {},
+) {
+    val colorTheme = MaterialTheme.linkuColors
+
+    Box(
+        modifier = modifier
+            .fillMaxSize()
+            .background(colorTheme.white),
+    ) {
+        RadialGradientCircle(
+            color = colorTheme.accentColor,
+            alpha = 0.16f,
+            size = 640.scaler,
+            modifier = Modifier.offset(x = (-191).scaler, y = 59.scaler),
+        )
+        RadialGradientCircle(
+            color = colorTheme.blue[200],
+            alpha = 0.16f,
+            size = 661.scaler,
+            modifier = Modifier
+                .align(Alignment.BottomEnd)
+                .offset(x = 57.scaler, y = (-28).scaler),
+        )
+        content() // 여기가 핵심입니당
+    }
+}
+
+@Preview(name = "큐레이션 카드 상세 그라데이션 원 고정 배경 (#44-1-1)", showBackground = true)
+@Composable
+private fun CurationGradientCircleBackgroundPreview() {
+    LinkuPreview {
+        CurationGradientCircleBackground()
+    }
+}


### PR DESCRIPTION
## 📝 설명
> - #44-1 "저장만 하고 열어보지 않은 링크" 큐레이션 리마인드 화면 UI 구현
- 스크롤해도 고정되는 핑크/파랑 그라데이션 원 배경(#44-1-1) 컴포넌트 분리
- Paging3 기반 무한 스크롤 링크 리스트 + 빈 상태(링크 0개) 헤더 분기 처리
- 큐레이션 메인 화면 3번 카드 클릭 시 리마인드 화면으로 이동하도록 연결

### 주요 변경
- `CurationGradientCircleBackground`: 스크롤 컨텐츠 뒤에 고정되는 핑크(Ellipse 539)/파랑(Ellipse 540) 그라데이션 원 배경 컴포넌트 추가 (`RadialGradientCircle` 재사용)
- `CurationRemindScreen`: `CurationTopHeader` + `LazyColumn`(`LinkCardItem`)으로 리마인드 화면 구성. 헤더-리스트 간 44 간격을 스크롤 안 되는 고정 여백으로 처리, 링크 0개일 때 헤더만 다른 위치/문구로 보여주는 빈 상태 분기 추가
- `CurationViewModel`: `LinkSimpleInfo`를 페이징하는 `remindLinks: Flow<PagingData<LinkSimpleInfo>>` 추가. `PagingConfig.initialLoadSize`를 `pageSize`와 동일하게 고정해서 첫 로드 시 기본 동작(pageSize*3)으로 과하게 불러오는 것 방지
- `RemindLinkPagingSource`: `CurationApi`/`CurationRepository`(princeHw 작업)가 준비되기 전까지 사용할 임시 로컬 더미 `PagingSource`. API 연동 시 교체/삭제할 부분은 코드 내 TODO로 표시
- `CurationScreen`: 카드 클릭 콜백 이름을 목적지 화면에 맞춰 `onCard1Click` → `onMonthlyDetailClick`, `onCard3Click` → `onRemindClick`으로 변경
- `CurationGraph`: 위 이름 변경에 맞춰 `curation_card3` 라우트 연결부 수정 (3번 카드 → `CurationRemindScreen`)
- `feature/curation/build.gradle.kts`: `paging-runtime`, `paging-compose` 의존성 추가
### 알려진 제한사항 (더미 데이터 관련)
- 헤더의 "총 N개의 링크" 문구는 지금은 `itemCount`(페이징으로 불러온 개수)를 써서 스크롤할수록 값이 커짐. API 연동 후 서버가 내려주는 "전체 저장 링크 수" 필드로 교체 필요 (코드에 TODO 표시)
- `CurationApi`/`CurationRepository`가 아직 빈 스텁이라 더미 데이터로 화면만 구성함


### 스크린 구성
| 상태 | 설명 | 이미지 |
| --- | --- | --- |
| 정상 (링크 있음) | 헤더(지난달 안읽은 링크 안내) + 무한 스크롤 링크 리스트 |<video src="https://github.com/user-attachments/assets/c68fd91b-8674-43df-a1b8-e7c158b29023" muted autoplay loop width="100%" />|
| 빈 상태 (링크 0개) | 헤더만 화면 상단에서 406만큼 아래에 노출 |<img width="454" height="930" alt="image" src="https://github.com/user-attachments/assets/93a37a7e-4f6a-471a-9c3d-4136fa8ec34d" />|
| 배경 단독 | 핑크/파랑 그라데이션 원 고정 배경 |<img width="336" height="684" alt="image" src="https://github.com/user-attachments/assets/84fa1d28-4b86-42b4-8efb-3fa90b8c3969" /> |


## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> #171 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 큐레이션의 “지난 달 리마인드” 화면이 추가되어, 저장했지만 아직 열어보지 않은 링크를 목록으로 확인할 수 있습니다.
  * 스크롤 가능한 목록과 빈 상태 화면이 함께 제공되며, 더 보기 로딩도 지원합니다.
  * 큐레이션 화면에 월간 상세와 리마인드로 이동하는 동작이 추가되었습니다.
  * 큐레이션 화면에 그라데이션 원형 배경이 적용되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->