### PR TITLE
 [Feature]: 폴더 스켈레톤 로딩 화면 생성

### DIFF
--- a/design/src/main/java/com/linku/design/modifier/Shadow.kt
+++ b/design/src/main/java/com/linku/design/modifier/Shadow.kt
@@ -1,0 +1,30 @@
+package com.linku.design.modifier
+
+import androidx.compose.runtime.Immutable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.shadow
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.DefaultShadowColor
+import androidx.compose.ui.graphics.RectangleShape
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+
+@Immutable
+data class ShadowStyle(
+    val elevation: Dp,
+    val shape: Shape = RectangleShape,
+    val clip: Boolean = elevation > 0.dp,
+    val ambientColor: Color = DefaultShadowColor,
+    val spotColor: Color = DefaultShadowColor
+)
+
+fun Modifier.shadow(
+    style: ShadowStyle
+): Modifier = shadow(
+    elevation = style.elevation,
+    shape = style.shape,
+    clip = style.clip,
+    ambientColor = style.ambientColor,
+    spotColor = style.spotColor
+)

--- a/design/src/main/java/com/linku/design/modifier/Skeleton.kt
+++ b/design/src/main/java/com/linku/design/modifier/Skeleton.kt
@@ -5,7 +5,6 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithCache
@@ -16,6 +15,37 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.CompositingStrategy
 import androidx.compose.ui.graphics.graphicsLayer
 
+/**
+ * 로딩 상태의 컴포저블에 스켈레톤 shimmer 효과를 적용하는 [Modifier]입니다.
+ *
+ * 이 modifier는 대상 컴포저블의 실제 콘텐츠를 먼저 그린 뒤, 그 콘텐츠가 차지하는 픽셀 영역만
+ * 그라데이션으로 덮어 shimmer처럼 보이게 만듭니다. 따라서 이 modifier를 적용한 컴포저블의
+ * 크기, 모양, clip, alpha는 그대로 스켈레톤 마스크의 기준이 됩니다.
+ *
+ * [isLoading]이 `false`이면 추가 draw 단계와 무한 애니메이션을 만들지 않고 기존 [Modifier]
+ * 체인을 그대로 반환합니다. 로딩이 끝난 뒤 실제 UI를 보여줄 때도 같은 modifier 체인을 유지할 수
+ * 있도록 하기 위한 동작입니다.
+ *
+ * 내부에서는 [CompositingStrategy.Offscreen]으로 별도 버퍼에 대상 컴포저블을 먼저 렌더링한 뒤,
+ * [BlendMode.SrcIn]을 사용해 실제로 그려진 픽셀 영역에만 [Brush.linearGradient]를 합성합니다.
+ * 이 처리가 없으면 shimmer 그라데이션이 현재 컴포저블 바깥이나 다른 컴포저블의 배경까지 영향을
+ * 줄 수 있습니다.
+ *
+ * 사용 예:
+ * ```
+ * Box(
+ *     modifier = Modifier
+ *         .size(width = 120.dp, height = 16.dp)
+ *         .clip(RoundedCornerShape(4.dp))
+ *         .skeleton(isLoading = uiState.isLoading)
+ * )
+ * ```
+ *
+ * @param isLoading `true`이면 shimmer 스켈레톤을 표시하고, `false`이면 원본 modifier를 그대로 사용합니다.
+ * @param baseColor 스켈레톤의 기본 배경색입니다. 그라데이션의 양 끝 색상으로 사용됩니다.
+ * @param highlightColor shimmer가 지나가는 중앙 하이라이트 색상입니다.
+ * @param durationMillis shimmer 그라데이션이 한 번 이동하는 데 걸리는 시간입니다.
+ */
 fun Modifier.skeleton(
     isLoading: Boolean,
     baseColor: Color = Color.LightGray.copy(alpha = 0.3f),
@@ -46,10 +76,10 @@ fun Modifier.skeleton(
     this
         .graphicsLayer {
             /*
-             * 컴포넌트를 별도의 버퍼에 그립니다.
+             * 현재 컴포저블을 별도 버퍼에 먼저 그립니다.
              *
-             * BlendMode가 화면의 다른 컴포넌트나 배경에 영향을 주지 않고
-             * 현재 컴포넌트 안에서만 동작하도록 하기 위해 필요합니다.
+             * BlendMode가 화면 전체나 다른 컴포저블의 배경에 영향을 주지 않고,
+             * 현재 컴포저블 내부에서만 동작하도록 하기 위해 필요합니다.
              */
             compositingStrategy = CompositingStrategy.Offscreen
         }
@@ -75,14 +105,13 @@ fun Modifier.skeleton(
 
             onDrawWithContent {
                 /*
-                 * 먼저 원본 컴포넌트를 그립니다.
-                 * 이 원본의 알파값이 마스크 역할을 합니다.
+                 * 먼저 원본 컴포저블을 그립니다.
+                 * 이 원본의 알파 값이 그라데이션을 입힐 마스크가 됩니다.
                  */
                 drawContent()
 
                 /*
-                 * 원본 컴포넌트가 실제로 그려진 픽셀에만
-                 * 그라데이션을 남깁니다.
+                 * 원본 컴포저블이 실제로 그려진 픽셀 영역에만 그라데이션을 합성합니다.
                  */
                 drawRect(
                     brush = brush,

--- a/design/src/main/java/com/linku/design/modifier/Skeleton.kt
+++ b/design/src/main/java/com/linku/design/modifier/Skeleton.kt
@@ -5,44 +5,17 @@ import androidx.compose.animation.core.animateFloat
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
-import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.composed
 import androidx.compose.ui.draw.drawWithCache
 import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.graphics.BlendMode
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.sp
-import com.linku.design.theme.linkuColors
-import com.linku.design.theme.linkuFont
+import androidx.compose.ui.graphics.CompositingStrategy
+import androidx.compose.ui.graphics.graphicsLayer
 
-/**
- * UI 구성 요소에 스켈레톤(Skeleton) 로딩 효과를 적용합니다.
- *
- * [isLoading]이 true일 때, 선형 그라데이션 애니메이션을 콘텐츠 위에 덮어씌워
- * 데이터가 로딩 중임을 나타내는 플레이스홀더 효과를 생성합니다.
- *
- * @param isLoading 스켈레톤 효과를 활성화할지 여부입니다.
- * @param baseColor 스켈레톤의 기본 배경색입니다.
- * @param highlightColor 스켈레톤 위를 지나가는 하이라이트(반짝임)의 색상입니다.
- * @param durationMillis 하이라이트 애니메이션이 한 번 반복되는 데 걸리는 시간(밀리초)입니다.
- * @return 스켈레톤 효과가 적용된 [Modifier]를 반환합니다.
- *
- * @sample
- * val isLoading = remember { mutableStateOf(false) }
- * Box(
- *     modifier = Modifier
- *         .fillMaxSize()
- *         .skeleton(isLoading = isLoading)
- * )
- */
 fun Modifier.skeleton(
     isLoading: Boolean,
     baseColor: Color = Color.LightGray.copy(alpha = 0.3f),
@@ -50,56 +23,71 @@ fun Modifier.skeleton(
     durationMillis: Int = 1000
 ): Modifier = composed {
 
-    if (!isLoading) return@composed this
+    if (!isLoading) {
+        return@composed this
+    }
 
-    // 애니메이션 상태
-    val transition = rememberInfiniteTransition(label = "skeleton")
+    val transition = rememberInfiniteTransition(
+        label = "skeleton"
+    )
 
     val progress = transition.animateFloat(
         initialValue = 0f,
         targetValue = 1f,
         animationSpec = infiniteRepeatable(
-            animation = tween(durationMillis, easing = LinearEasing)
+            animation = tween(
+                durationMillis = durationMillis,
+                easing = LinearEasing
+            )
         ),
-        label = "progress"
+        label = "skeletonProgress"
     )
 
-    this.drawWithCache {
-
-        val width = size.width
-        val height = size.height
-
-        val brush = Brush.linearGradient(
-            colors = listOf(baseColor, highlightColor, baseColor),
-            start = Offset(progress.value * width - width, 0f),
-            end = Offset(progress.value * width, height)
-        )
-
-        onDrawWithContent {
-            // 기존 UI를 덮어버림 (skeleton 상태)
-            drawRect(brush)
+    this
+        .graphicsLayer {
+            /*
+             * 컴포넌트를 별도의 버퍼에 그립니다.
+             *
+             * BlendMode가 화면의 다른 컴포넌트나 배경에 영향을 주지 않고
+             * 현재 컴포넌트 안에서만 동작하도록 하기 위해 필요합니다.
+             */
+            compositingStrategy = CompositingStrategy.Offscreen
         }
-    }
-}
+        .drawWithCache {
+            val width = size.width
+            val height = size.height
 
-@Preview(showBackground = true)
-@Composable
-private fun SkeletonPreview() {
-    val isLoading = remember { mutableStateOf(false) }
+            val brush = Brush.linearGradient(
+                colors = listOf(
+                    baseColor,
+                    highlightColor,
+                    baseColor
+                ),
+                start = Offset(
+                    x = progress.value * width - width,
+                    y = 0f
+                ),
+                end = Offset(
+                    x = progress.value * width,
+                    y = height
+                )
+            )
 
-    Text(
-        modifier = Modifier
-            .fillMaxSize()
-            .noRippleClickable {
-                isLoading.value = !isLoading.value
+            onDrawWithContent {
+                /*
+                 * 먼저 원본 컴포넌트를 그립니다.
+                 * 이 원본의 알파값이 마스크 역할을 합니다.
+                 */
+                drawContent()
+
+                /*
+                 * 원본 컴포넌트가 실제로 그려진 픽셀에만
+                 * 그라데이션을 남깁니다.
+                 */
+                drawRect(
+                    brush = brush,
+                    blendMode = BlendMode.SrcIn
+                )
             }
-            .skeleton(
-                isLoading = isLoading.value
-            ),
-        text = "Click",
-        textAlign = TextAlign.Center,
-        fontSize = 25.sp,
-        fontFamily = MaterialTheme.linkuFont.font,
-        color = MaterialTheme.linkuColors.black
-    )
+        }
 }

--- a/feature/file/src/main/java/com/linku/file/ui/content/LoadingFoldersGrid.kt
+++ b/feature/file/src/main/java/com/linku/file/ui/content/LoadingFoldersGrid.kt
@@ -1,0 +1,69 @@
+package com.linku.file.ui.content
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.linku.file.ui.item.items.SkeletonFolderItem
+import com.linku.file.ui.theme.LinkU_AndroidTheme
+
+private const val INTER_LAYER_PADDING = 18.51
+private const val ITEM_RATIO = 10f / 174f
+
+/**
+ * 폴더 데이터를 불러오는 동안 표시되는 로딩 스켈레톤 그리드 화면입니다.
+ *
+ * 2열 그리드 레이아웃을 사용하여 스켈레톤 아이템을 배치하며, 화면 너비와
+ * 사전 정의된 비율([ITEM_RATIO])에 따라 아이템 간의 수평 간격을 동적으로 계산합니다.
+ *
+ * @param modifier 그리드 전체 컨테이너에 적용할 [Modifier]입니다.
+ * @param contentPadding 그리드 내부 콘텐츠에 적용할 여백입니다.
+ */
+@Composable
+internal fun LoadingFoldersGrid(
+    modifier: Modifier = Modifier,
+    contentPadding: PaddingValues = PaddingValues(top = 20.dp, start = 20.dp, end = 20.dp, bottom = 60.dp),
+) {
+    val layoutDirection = LocalLayoutDirection.current
+
+    BoxWithConstraints(
+        modifier = modifier.fillMaxSize()
+    ) {
+        val horizontalPadding =
+            contentPadding.calculateStartPadding(layoutDirection) +
+                    contentPadding.calculateEndPadding(layoutDirection)
+        val availableWidth = maxWidth - horizontalPadding
+        val horizontalSpacing = availableWidth * ITEM_RATIO
+
+        LazyVerticalGrid(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = contentPadding,
+            columns = GridCells.Fixed(2),
+            verticalArrangement = Arrangement.spacedBy(INTER_LAYER_PADDING.dp),
+            horizontalArrangement = Arrangement.spacedBy(horizontalSpacing),
+        ) {
+            items(
+                count = 10
+            ) {
+                SkeletonFolderItem(Modifier.fillMaxSize())
+            }
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun LoadingFoldersGridPreview() {
+    LinkU_AndroidTheme {
+        LoadingFoldersGrid()
+    }
+}

--- a/feature/file/src/main/java/com/linku/file/ui/content/LoadingLinksGrid.kt
+++ b/feature/file/src/main/java/com/linku/file/ui/content/LoadingLinksGrid.kt
@@ -1,0 +1,5 @@
+package com.linku.file.ui.content
+
+internal fun LoadingLinksGrid(){
+
+}

--- a/feature/file/src/main/java/com/linku/file/ui/item/items/SkeletonFolderItem.kt
+++ b/feature/file/src/main/java/com/linku/file/ui/item/items/SkeletonFolderItem.kt
@@ -33,6 +33,15 @@ private const val baseW = 165.3f
 private const val baseH = 145.8535f
 private const val aspect = baseW / baseH
 
+/**
+ * 폴더 아이템의 로딩 상태를 표시하는 스켈레톤 로더 컴포넌트입니다.
+ *
+ * 여러 개의 레이어를 회전시키고 겹쳐서 폴더 내부의 종이 뭉치를 표현하며,
+ * 하단 마스크를 통해 폴더의 외형을 완성합니다. 지정된 종횡비([aspect])를 유지하며
+ * 전달된 [modifier]의 크기에 맞춰 내부 요소들이 동적으로 스케일링됩니다.
+ *
+ * @param modifier 컨테이너 레이아웃에 적용할 [Modifier]
+ */
 @Composable
 internal fun SkeletonFolderItem(
     modifier: Modifier
@@ -46,7 +55,7 @@ internal fun SkeletonFolderItem(
         val scaleH = maxHeight / baseH.dp
         val scale = minOf(scaleW, scaleH)
 
-        // 디자인 기준 dp, sp를 현재 카드 크기에 맞게 변환하는 헬퍼입니다.
+        /** 디자인 기준 dp, sp를 현재 카드 크기에 맞게 변환하는 헬퍼입니다. */
         fun s(dp: Dp) = dp * scale
 
         /**
@@ -91,6 +100,7 @@ internal fun SkeletonFolderItem(
             Modifier.fillMaxSize(),
             contentAlignment = Alignment.Center
         ) {
+            // 배경면. SkeletonFolderItem 자체가 갖는 크기를 가짐.
             Surface(
                 modifier = Modifier
                     .fillMaxSize()
@@ -120,6 +130,7 @@ internal fun SkeletonFolderItem(
                 rotation = 0f
             )
 
+            // 하단 폴더 마스크.
             Image(
                 painter = painterResource(R.drawable.folder_mask),
                 contentScale = ContentScale.FillWidth,

--- a/feature/file/src/main/java/com/linku/file/ui/item/items/SkeletonFolderItem.kt
+++ b/feature/file/src/main/java/com/linku/file/ui/item/items/SkeletonFolderItem.kt
@@ -1,0 +1,142 @@
+package com.linku.file.ui.item.items
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Surface
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.LayoutDirection
+import androidx.compose.ui.unit.dp
+import com.linku.design.modifier.skeleton
+import com.linku.design.theme.LinkuPreview
+import com.linku.file.R
+
+private const val baseW = 165.3f
+private const val baseH = 145.8535f
+private const val aspect = baseW / baseH
+
+@Composable
+internal fun SkeletonFolderItem(
+    modifier: Modifier
+){
+
+    BoxWithConstraints(
+        modifier = modifier
+            .aspectRatio(aspect, matchHeightConstraintsFirst = false)
+    ) {
+        val scaleW = maxWidth / baseW.dp
+        val scaleH = maxHeight / baseH.dp
+        val scale = minOf(scaleW, scaleH)
+
+        // 디자인 기준 dp, sp를 현재 카드 크기에 맞게 변환하는 헬퍼입니다.
+        fun s(dp: Dp) = dp * scale
+
+        /**
+         * 폴더 일러스트를 구성하는 단일 레이어를 현재 카드 크기에 맞춰 그립니다.
+         *
+         * @param size 레이어의 기준 너비입니다.
+         * @param height 레이어의 기준 높이입니다. 지정하지 않으면 [size]와 같은 값으로 사용합니다.
+         * @param padding 기준 크기에서 적용할 외부 여백입니다.
+         * @param rotation 레이어에 적용할 회전 각도입니다.
+         */
+        @Composable
+        fun FolderLayerBox(
+            size: Dp,
+            height: Dp = size,
+            padding: PaddingValues = PaddingValues(0.dp),
+            rotation: Float = 0f,
+        ) {
+            /** 회전과 그림자를 가진 폴더 뒷장/중간장/앞장 레이어입니다. */
+            Surface(
+                modifier = Modifier
+                    // 레이어별 기준 여백을 현재 카드 스케일에 맞게 변환합니다.
+                    .padding(
+                        PaddingValues(
+                            start = s(padding.calculateStartPadding(LayoutDirection.Ltr)),
+                            top = s(padding.calculateTopPadding()),
+                            end = s(padding.calculateEndPadding(LayoutDirection.Ltr)),
+                            bottom = s(padding.calculateBottomPadding())
+                        )
+                    )
+                    // 레이어마다 다른 회전값을 적용해 폴더 종이가 겹친 느낌을 만듭니다.
+                    .rotate(rotation)
+                    // 레이어의 기준 너비/높이를 현재 카드 크기에 맞춰 스케일링합니다.
+                    .width(s(size))
+                    .height(s(height))
+                    .skeleton(isLoading = true),
+                shape = RoundedCornerShape(s(18.dp)),
+            ) {}
+        }
+
+        /** 폴더 레이어와 하단 마스크를 카드 중앙 기준으로 겹쳐 배치하는 루트 컨테이너입니다. */
+        Box(
+            Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center
+        ) {
+            Surface(
+                modifier = Modifier
+                    .fillMaxSize()
+                    .skeleton(isLoading = true),
+                shape = RoundedCornerShape(28.5.dp)
+            ){}
+
+            // 첫 번째 레이어: 가장 뒤쪽 종이입니다. 원본: 105.45, padding bottom 5.7, rot -7.39
+            FolderLayerBox(
+                size = 105.45.dp,
+                padding = PaddingValues(bottom = 5.7.dp),
+                rotation = -7.39f
+            )
+
+            // 두 번째 레이어: 가운데 종이입니다. 원본: 105.45, padding bottom 3.1825, rot 4.86
+            FolderLayerBox(
+                size = 105.45.dp,
+                padding = PaddingValues(bottom = 3.1825.dp),
+                rotation = 4.86f
+            )
+
+            // 세 번째 레이어: 가장 앞쪽 흰색/컬러 종이입니다. 원본: size 126.407 x 107.9605, padding top 7.6
+            FolderLayerBox(
+                size = 126.407.dp,
+                height = 107.9605.dp,
+                padding = PaddingValues(top = 7.6.dp),
+                rotation = 0f
+            )
+
+            Image(
+                painter = painterResource(R.drawable.folder_mask),
+                contentScale = ContentScale.FillWidth,
+                contentDescription = null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter)
+                    .skeleton(isLoading = true)
+            )
+        }
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun SkeletonFolderItemPreview(){
+    LinkuPreview {
+        SkeletonFolderItem(Modifier.fillMaxSize())
+    }
+}


### PR DESCRIPTION
## 📝 설명
> 해당 PR이 진행한 사항을 자세히 적어주세요.

- 폴더 데이터를 불러오는 동안 표시할 2열 로딩 스켈레톤 그리드를 추가했습니다.
- 폴더 카드 형태를 반영한 `SkeletonFolderItem`을 추가하고, 화면 크기에 맞춰 내부 레이어와 마스크가 스케일링되도록 구성했습니다.
- `Modifier.skeleton`이 실제 콘텐츠가 그려진 영역에만 shimmer 그라데이션을 합성하도록 `Offscreen` 합성과 `BlendMode.SrcIn` 기반으로 개선했습니다.
- 스켈레톤 modifier와 폴더 스켈레톤 컴포넌트의 KDoc 및 구현 주석을 보강했습니다.
- `LoadingLinksGrid` internal 함수 선언을 추가했습니다.

## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> 해당 PR과 관련된 이슈 번호를 적어주세요.

없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 폴더 데이터 로딩 중 2열 로딩 스켈레톤 그리드를 표시합니다.
  * 폴더 카드 형태를 반영한 마스크 기반 스켈레톤 아이템을 제공합니다.
  * 그림자 스타일을 값 객체로 정의해 `Modifier.shadow(...)`로 쉽게 적용할 수 있습니다.
* **버그 수정**
  * 스켈레톤 그라데이션이 실제 콘텐츠가 그려진 영역에만 적용되도록 개선하여 불필요한 색상 표시를 방지합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->