### PR TITLE
🐛 fix(ui): 스플래시→로그인→홈 전환 시 시스템 바 색상 불일치 수정

### DIFF
--- a/app/src/main/java/com/linku/MainActivity.kt
+++ b/app/src/main/java/com/linku/MainActivity.kt
@@ -15,7 +15,6 @@ import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity(), SystemBarController {
-    private var currentSystemBarMode: SystemBarMode? = null
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -49,9 +48,9 @@ class MainActivity : ComponentActivity(), SystemBarController {
      * 앱 전역 시스템 바 단일 제어 지점
      */
     override fun setSystemBarMode(mode: SystemBarMode) {
-        if (currentSystemBarMode == mode) return
-        currentSystemBarMode = mode
-
+        // DesignSystemBars(Compose SideEffect)가 같은 Window를 별도로 직접 제어하기 때문에
+        // 이전 호출 결과를 캐시해서 조기 반환하면 실제 상태와 어긋나 복구 호출이 무시될 수 있음.
+        // 그래서 매번 무조건 반영함(hide/show는 반복 호출해도 안전함).
         WindowCompat.setDecorFitsSystemWindows(
             window,
             mode == SystemBarMode.VISIBLE

--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -142,10 +142,7 @@ fun MainApp(
     // (edge-to-edge) 화면에서만 true. 그 외 화면은 전부 흰 상태바 스크림을 켜야 하므로 기본은 false.
     // Splash가 시작 화면이라 초기값만 true.
     var edgeToEdgeSystemBars by rememberSaveable { mutableStateOf(true) }
-
-    // File 탭처럼 상태바 뒤로 어두운 색(그라데이션)이 비치는 화면이 떠 있는 동안만 true로 바뀜.
-    // 그동안은 상태바 글자/아이콘을 흰색으로 보여줌.
-    var statusBarLightIcons by rememberSaveable { mutableStateOf(false) }
+    // 상태바 아이콘 밝기(File 탭 등)는 LocalStatusBarDarkIcons로 화면이 직접 제어함 (MainScreen.kt 참고).
 
     // TODO : 로그인 뷰모델에서 Success 상태로 바꾸기 전에 세션 갱신하게 수정해야함.
     // 기기가 3대라 이렇게 되면 사용자 정보가 따로 놀 수 있음.
@@ -253,8 +250,7 @@ fun MainApp(
             ) else null,
             centerButtonProp = null, // 바로 이동하므로 null
             onFABClick = { saveLinkEntryTriggered = true },
-            applyDefaultSystemBarIcons = !edgeToEdgeSystemBars,
-            statusBarDarkIcons = !statusBarLightIcons
+            applyDefaultSystemBarIcons = !edgeToEdgeSystemBars
         ) {
             NavHost(
                 navController = navigator,
@@ -407,8 +403,7 @@ fun MainApp(
 
                         FileApp(
                             fileViewModel = fileViewModel,
-                            folderStateViewModel = folderStateViewModel,
-                            onLightStatusBarIconsChange = { statusBarLightIcons = it }
+                            folderStateViewModel = folderStateViewModel
                         )
                     }
                 }

--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -136,17 +136,16 @@ fun MainApp(
     // 마이페이지에서 사용할 뷰모델
     val mypageViewModel: MyPageViewModel = hiltViewModel()
 
-    // TODO : 안드로이드 팀원들에게 물어보기. 이거 rememberSaveable로 변경을 해야하는 건 아닌지.
-    var showNavBar by remember { mutableStateOf(false) }
+    var showNavBar by rememberSaveable { mutableStateOf(false) }
 
     // 스플래시 애니메이션, 로그인 그라데이션 화면처럼 상태바 뒤로 콘텐츠가 그대로 비쳐야 하는
     // (edge-to-edge) 화면에서만 true. 그 외 화면은 전부 흰 상태바 스크림을 켜야 하므로 기본은 false.
     // Splash가 시작 화면이라 초기값만 true.
-    var edgeToEdgeSystemBars by remember { mutableStateOf(true) }
+    var edgeToEdgeSystemBars by rememberSaveable { mutableStateOf(true) }
 
     // File 탭처럼 상태바 뒤로 어두운 색(그라데이션)이 비치는 화면이 떠 있는 동안만 true로 바뀜.
     // 그동안은 상태바 글자/아이콘을 흰색으로 보여줌.
-    var statusBarLightIcons by remember { mutableStateOf(false) }
+    var statusBarLightIcons by rememberSaveable { mutableStateOf(false) }
 
     // TODO : 로그인 뷰모델에서 Success 상태로 바꾸기 전에 세션 갱신하게 수정해야함.
     // 기기가 3대라 이렇게 되면 사용자 정보가 따로 놀 수 있음.

--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -139,6 +139,15 @@ fun MainApp(
     // TODO : 안드로이드 팀원들에게 물어보기. 이거 rememberSaveable로 변경을 해야하는 건 아닌지.
     var showNavBar by remember { mutableStateOf(false) }
 
+    // 스플래시 애니메이션, 로그인 그라데이션 화면처럼 상태바 뒤로 콘텐츠가 그대로 비쳐야 하는
+    // (edge-to-edge) 화면에서만 true. 그 외 화면은 전부 흰 상태바 스크림을 켜야 하므로 기본은 false.
+    // Splash가 시작 화면이라 초기값만 true.
+    var edgeToEdgeSystemBars by remember { mutableStateOf(true) }
+
+    // File 탭처럼 상태바 뒤로 어두운 색(그라데이션)이 비치는 화면이 떠 있는 동안만 true로 바뀜.
+    // 그동안은 상태바 글자/아이콘을 흰색으로 보여줌.
+    var statusBarLightIcons by remember { mutableStateOf(false) }
+
     // TODO : 로그인 뷰모델에서 Success 상태로 바꾸기 전에 세션 갱신하게 수정해야함.
     // 기기가 3대라 이렇게 되면 사용자 정보가 따로 놀 수 있음.
 
@@ -244,7 +253,9 @@ fun MainApp(
                 }
             ) else null,
             centerButtonProp = null, // 바로 이동하므로 null
-            onFABClick = { saveLinkEntryTriggered = true }
+            onFABClick = { saveLinkEntryTriggered = true },
+            applyDefaultSystemBarIcons = !edgeToEdgeSystemBars,
+            statusBarDarkIcons = !statusBarLightIcons
         ) {
             NavHost(
                 navController = navigator,
@@ -258,7 +269,10 @@ fun MainApp(
                 //스플래쉬
                 with(NavigationRoute.Splash) {
                     setNavGraph {
-                        LaunchedEffect(Unit) { showNavBar = false }
+                        LaunchedEffect(Unit) {
+                            showNavBar = false
+                            edgeToEdgeSystemBars = true // 스플래시: 상태/내비게이션 바 완전히 숨김
+                        }
 
                         var autoLoginTried by rememberSaveable {
                             mutableStateOf(false)
@@ -271,6 +285,7 @@ fun MainApp(
                         LaunchedEffect(autoLoginState) {
                             when (autoLoginState) {
                                 is AutoLoginState.Success -> {
+                                    edgeToEdgeSystemBars = false
                                     homeViewModel.refreshAfterLogin()
                                     navigator.navigate(NavigationRoute.Home.route) {
                                         popUpTo(NavigationRoute.Splash.route) { inclusive = true }
@@ -315,8 +330,10 @@ fun MainApp(
                     LoginApp(
                         //navController = navigator,
                         loginViewModel = loginViewModel,
+                        onEdgeToEdgeChange = { edgeToEdgeSystemBars = it },
                         onLoginSuccess = {
                             showNavBar = true
+                            edgeToEdgeSystemBars = false
 
 
                             // TODO: 지민님 딥링크 대기 작업 처리 확인 필요 요청하기.
@@ -341,6 +358,7 @@ fun MainApp(
                         },
                         onAutoLoginSuccess = {
                             showNavBar = true
+                            edgeToEdgeSystemBars = false
                             homeViewModel.refreshAfterLogin()
                             navigator.navigate(NavigationRoute.Home.route) {
                                 popUpTo(NavigationRoute.Splash.route) { inclusive = true }
@@ -390,7 +408,8 @@ fun MainApp(
 
                         FileApp(
                             fileViewModel = fileViewModel,
-                            folderStateViewModel = folderStateViewModel
+                            folderStateViewModel = folderStateViewModel,
+                            onLightStatusBarIconsChange = { statusBarLightIcons = it }
                         )
                     }
                 }

--- a/app/src/main/java/com/linku/MainScreen.kt
+++ b/app/src/main/java/com/linku/MainScreen.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.tooling.preview.Preview
 import com.linku.component.LinkuNavigationBar
 import com.linku.design.theme.ThemeProvider
+import com.linku.design.util.EdgeToEdgeSystemBars
 import com.linku.navigation.LinkuNavigationItem
 
 data class NavigationBarProp(
@@ -43,12 +44,26 @@ fun MainScreen(
     navigationBarProp: NavigationBarProp?,
     centerButtonProp: CenterButtonProp?,
     onFABClick: () -> Unit,
+    // 스플래시, 로그인 그라데이션 화면처럼 자체적으로 시스템 바를 다루는(edge-to-edge) 화면에서만
+    // false로 넘김. 그 외 화면은 기본값(true) — 시스템 바 배경은 각 화면 콘텐츠가 그대로 확장되어
+    // 비치게 두고(edge-to-edge), 아이콘 밝기와 표시 여부만 여기서 공통으로 맞춰줌.
+    applyDefaultSystemBarIcons: Boolean = true,
+    // File 탭처럼 상태바 뒤로 어두운 색(그라데이션)이 비치는 화면에서만 false로 넘겨
+    // 상태바 글자/아이콘을 흰색으로 바꿈. 그 외엔 기본값(true)대로 검정.
+    statusBarDarkIcons: Boolean = true,
     content: @Composable () -> Unit,
 ) {
     val density = LocalDensity.current
     var navBarCenter by remember { mutableStateOf(Offset.Zero) }
     var navBarTopPx by remember { mutableFloatStateOf(0f) }     // ⬅️ 바의 top 좌표
     var navBarSizePx by remember { mutableStateOf(Size.Zero) }
+
+    // 시스템 바 "배경색"은 지정하지 않음 — 각 화면의 상단 색상(gray[100], 그라데이션 등)이
+    // 상태바/내비게이션 바까지 자연스럽게 확장되어 보이게(edge-to-edge) 둠.
+    // 아이콘 밝기와 바 표시만 공통으로 맞춤.
+    if (applyDefaultSystemBarIcons) {
+        EdgeToEdgeSystemBars(darkIcons = statusBarDarkIcons)
+    }
 
     Scaffold(
         contentWindowInsets = WindowInsets.safeDrawing.only(

--- a/app/src/main/java/com/linku/MainScreen.kt
+++ b/app/src/main/java/com/linku/MainScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.safeDrawing
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.mutableStateOf
@@ -27,6 +28,7 @@ import androidx.compose.ui.tooling.preview.Preview
 import com.linku.component.LinkuNavigationBar
 import com.linku.design.theme.ThemeProvider
 import com.linku.design.util.EdgeToEdgeSystemBars
+import com.linku.design.util.LocalStatusBarDarkIcons
 import com.linku.navigation.LinkuNavigationItem
 
 data class NavigationBarProp(
@@ -48,9 +50,6 @@ fun MainScreen(
     // false로 넘김. 그 외 화면은 기본값(true) — 시스템 바 배경은 각 화면 콘텐츠가 그대로 확장되어
     // 비치게 두고(edge-to-edge), 아이콘 밝기와 표시 여부만 여기서 공통으로 맞춰줌.
     applyDefaultSystemBarIcons: Boolean = true,
-    // File 탭처럼 상태바 뒤로 어두운 색(그라데이션)이 비치는 화면에서만 false로 넘겨
-    // 상태바 글자/아이콘을 흰색으로 바꿈. 그 외엔 기본값(true)대로 검정.
-    statusBarDarkIcons: Boolean = true,
     content: @Composable () -> Unit,
 ) {
     val density = LocalDensity.current
@@ -58,13 +57,19 @@ fun MainScreen(
     var navBarTopPx by remember { mutableFloatStateOf(0f) }     // ⬅️ 바의 top 좌표
     var navBarSizePx by remember { mutableStateOf(Size.Zero) }
 
+    // File 탭처럼 상태바 뒤로 어두운 배경(그라데이션 등)이 비치는 화면은 이 값을 직접
+    // false로 바꿔서 아이콘을 흰색으로 전환함(LocalStatusBarDarkIcons로 하위에 제공).
+    // MainApp까지 콜백을 relay할 필요 없이 화면이 바로 읽고 쓸 수 있음.
+    val statusBarDarkIcons = remember { mutableStateOf(true) }
+
     // 시스템 바 "배경색"은 지정하지 않음 — 각 화면의 상단 색상(gray[100], 그라데이션 등)이
     // 상태바/내비게이션 바까지 자연스럽게 확장되어 보이게(edge-to-edge) 둠.
     // 아이콘 밝기와 바 표시만 공통으로 맞춤.
     if (applyDefaultSystemBarIcons) {
-        EdgeToEdgeSystemBars(darkIcons = statusBarDarkIcons)
+        EdgeToEdgeSystemBars(darkIcons = statusBarDarkIcons.value)
     }
 
+    CompositionLocalProvider(LocalStatusBarDarkIcons provides statusBarDarkIcons) {
     Scaffold(
         contentWindowInsets = WindowInsets.safeDrawing.only(
             WindowInsetsSides.Bottom + WindowInsetsSides.Horizontal
@@ -108,6 +113,7 @@ fun MainScreen(
         ) {
             content()
         }
+    }
     }
 }
 

--- a/design/src/main/java/com/linku/design/util/StatusBarIconStyle.kt
+++ b/design/src/main/java/com/linku/design/util/StatusBarIconStyle.kt
@@ -1,0 +1,17 @@
+package com.linku.design.util
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.staticCompositionLocalOf
+
+/**
+ * 상태바/내비게이션 바 아이콘을 어둡게(검정) 보여줄지 여부를 화면(하위 컴포저블)에서
+ * 직접 읽고 바꿀 수 있게 하는 CompositionLocal.
+ *
+ * 기본은 true(검정 아이콘, 밝은 배경 기준). File 탭처럼 상태바 뒤로 어두운 배경(그라데이션 등)이
+ * 비치는 화면은 진입 시 false로 바꿨다가 [androidx.compose.runtime.DisposableEffect]의
+ * onDispose에서 다시 true로 되돌리면 됨. MainApp/MainScreen을 거치는 콜백 없이
+ * 화면이 직접 `LocalStatusBarDarkIcons.current.value`를 변경한다.
+ */
+val LocalStatusBarDarkIcons = staticCompositionLocalOf<MutableState<Boolean>> {
+    error("LocalStatusBarDarkIcons is not provided. MainScreen에서 CompositionLocalProvider로 감싸야 함.")
+}

--- a/design/src/main/java/com/linku/design/util/SystemBarPresets.kt
+++ b/design/src/main/java/com/linku/design/util/SystemBarPresets.kt
@@ -1,9 +1,8 @@
 package com.linku.design.util
 
-import android.app.Activity
 import android.os.Build
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
@@ -36,8 +35,15 @@ fun EdgeToEdgeSystemBars(darkIcons: Boolean = true) {
     val isPreview = LocalInspectionMode.current
     if (isPreview) return
 
-    SideEffect {
-        val window = (view.context as Activity).window
+    // SideEffect는 리컴포지션마다 실행되는데, Window/시스템 서버와 통신하는 호출들이라
+    // darkIcons가 실제로 바뀔 때(+최초 진입)만 실행되도록 key로 제한함.
+    DisposableEffect(darkIcons) {
+        val activity = view.context.findActivityOrNull()
+        if (activity == null) {
+            return@DisposableEffect onDispose {}
+        }
+
+        val window = activity.window
         val controller = WindowInsetsControllerCompat(window, view)
 
         // 항상 edge-to-edge: 화면 콘텐츠 색이 상태바/내비게이션 바 배경으로 그대로 확장됨.
@@ -58,6 +64,8 @@ fun EdgeToEdgeSystemBars(darkIcons: Boolean = true) {
             window.isStatusBarContrastEnforced = false
             window.isNavigationBarContrastEnforced = false
         }
+
+        onDispose {}
     }
 }
 

--- a/design/src/main/java/com/linku/design/util/SystemBarPresets.kt
+++ b/design/src/main/java/com/linku/design/util/SystemBarPresets.kt
@@ -1,35 +1,81 @@
 package com.linku.design.util
 
+import android.app.Activity
+import android.os.Build
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.graphics.Color
+import androidx.compose.runtime.SideEffect
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.platform.LocalView
+import androidx.core.view.WindowCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.WindowInsetsControllerCompat
 
 /**
  * 앱에서 자주 쓰는 SystemBar 프리셋들
  */
 
+// 현재 호출부 없음(EdgeToEdgeSystemBars로 대체됨). 다크모드 지원 추가할 때 프리셋별로
+// 색상을 다시 다뤄야 할 수 있어 삭제하지 않고 주석으로 남겨둠.
+//@Composable
+//fun WhiteSystemBars() { //안드로이드 자체 바텀바 흰색 적용
+//    DesignSystemBars(
+//        statusBarColor = Color.White,
+//        navigationBarColor = Color.White,
+//        darkIcons = true
+//    )
+//}
+
+/**
+ * 시스템 바 배경에 별도 색을 칠하지 않고 각 화면의 콘텐츠가 상태바/내비게이션 바 뒤까지
+ * 자연스럽게 이어져 보이게(edge-to-edge) 두는 기본 프리셋. 아이콘 밝기와 표시 여부만 맞춤.
+ * 이 프로젝트의 "일반 화면(스플래시/로그인 그라데이션 제외)" 기본값으로 사용됨.
+ */
 @Composable
-fun WhiteSystemBars() { //안드로이드 자체 바텀바 흰색 적용
-    DesignSystemBars(
-        statusBarColor = Color.White,
-        navigationBarColor = Color.White,
-        darkIcons = true
-    )
+fun EdgeToEdgeSystemBars(darkIcons: Boolean = true) {
+    val view = LocalView.current
+    val isPreview = LocalInspectionMode.current
+    if (isPreview) return
+
+    SideEffect {
+        val window = (view.context as Activity).window
+        val controller = WindowInsetsControllerCompat(window, view)
+
+        // 항상 edge-to-edge: 화면 콘텐츠 색이 상태바/내비게이션 바 배경으로 그대로 확장됨.
+        WindowCompat.setDecorFitsSystemWindows(window, false)
+
+        controller.show(
+            WindowInsetsCompat.Type.statusBars() or
+                    WindowInsetsCompat.Type.navigationBars()
+        )
+        controller.systemBarsBehavior = WindowInsetsControllerCompat.BEHAVIOR_DEFAULT
+
+        controller.isAppearanceLightStatusBars = darkIcons
+        controller.isAppearanceLightNavigationBars = darkIcons
+
+        // OS가 자동으로 그려주는 반투명 명암 보정 스크림을 꺼서, 화면 색이 흐려지지 않고
+        // 그대로 비치게 함. (API 29+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isStatusBarContrastEnforced = false
+            window.isNavigationBarContrastEnforced = false
+        }
+    }
 }
 
-@Composable
-fun TransparentSystemBars(darkIcons: Boolean = false) {
-    DesignSystemBars(
-        statusBarColor = Color.Transparent,
-        navigationBarColor = Color.Transparent,
-        darkIcons = darkIcons
-    )
-}
-
-@Composable
-fun DarkSystemBars() {
-    DesignSystemBars(
-        statusBarColor = Color.Black,
-        navigationBarColor = Color.Black,
-        darkIcons = false
-    )
-}
+// 현재 호출부 없음. 다크모드 지원 시 필요할 수 있어 삭제하지 않고 주석으로 남겨둠.
+//@Composable
+//fun TransparentSystemBars(darkIcons: Boolean = false) {
+//    DesignSystemBars(
+//        statusBarColor = Color.Transparent,
+//        navigationBarColor = Color.Transparent,
+//        darkIcons = darkIcons
+//    )
+//}
+//
+//@Composable
+//fun DarkSystemBars() {
+//    DesignSystemBars(
+//        statusBarColor = Color.Black,
+//        navigationBarColor = Color.Black,
+//        darkIcons = false
+//    )
+//}

--- a/design/src/main/java/com/linku/design/util/SystemBars.kt
+++ b/design/src/main/java/com/linku/design/util/SystemBars.kt
@@ -1,9 +1,11 @@
 package com.linku.design.util
 
 import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import android.os.Build
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalInspectionMode
@@ -11,6 +13,20 @@ import androidx.compose.ui.platform.LocalView
 import androidx.core.view.WindowCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
+
+/**
+ * [Context]가 (테마가 적용된 [ContextWrapper] 등으로) 감싸져 있어도 그 안의 실제
+ * [Activity]를 찾아냄. 바로 `as Activity`로 캐스팅하면 감싸진 Context일 때
+ * [ClassCastException]으로 크래시할 수 있어 안전하게 언래핑함.
+ */
+internal fun Context.findActivityOrNull(): Activity? {
+    var context = this
+    while (context is ContextWrapper) {
+        if (context is Activity) return context
+        context = context.baseContext
+    }
+    return context as? Activity
+}
 
 /**
  * Design module – Android System Bars controller
@@ -37,8 +53,14 @@ fun DesignSystemBars(
     val isPreview = LocalInspectionMode.current
     if (isPreview) return
 
-    SideEffect {
-        val window = (view.context as Activity).window
+    // 매 리컴포지션마다가 아니라 실제로 값이 바뀔 때만 Window/시스템 서버와 통신하도록 함.
+    DisposableEffect(statusBarColor, navigationBarColor, darkIcons, immersive) {
+        val activity = view.context.findActivityOrNull()
+        if (activity == null) {
+            return@DisposableEffect onDispose {}
+        }
+
+        val window = activity.window
         val controller = WindowInsetsControllerCompat(window, view)
 
         WindowCompat.setDecorFitsSystemWindows(window, !immersive)
@@ -76,5 +98,7 @@ fun DesignSystemBars(
             window.isStatusBarContrastEnforced = false
             window.isNavigationBarContrastEnforced = false
         }
+
+        onDispose {}
     }
 }

--- a/design/src/main/java/com/linku/design/util/SystemBars.kt
+++ b/design/src/main/java/com/linku/design/util/SystemBars.kt
@@ -1,6 +1,7 @@
 package com.linku.design.util
 
 import android.app.Activity
+import android.os.Build
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
 import androidx.compose.ui.graphics.Color
@@ -18,6 +19,11 @@ import androidx.core.view.WindowInsetsControllerCompat
  * - 아이콘 밝기 제어
  * - edge-to-edge 환경 공통 처리
  */
+// statusBarColor/navigationBarColor/isStatusBarContrastEnforced/isNavigationBarContrastEnforced는
+// Android 15(API 35)부터 deprecated(edge-to-edge 강제로 no-op)이지만, 이 화면들(Login 계열,
+// immersive = true)은 스와이프로 바를 잠깐 꺼냈을 때(BEHAVIOR_SHOW_TRANSIENT_BARS_BY_SWIPE)
+// API 34 이하 기기에서는 여전히 실제로 그려지므로 의도적으로 유지함.
+@Suppress("DEPRECATION")
 @Composable
 fun DesignSystemBars(
     statusBarColor: Color = Color.White, //상태바 배경 색상
@@ -54,10 +60,21 @@ fun DesignSystemBars(
             )
         }
 
+        // Android 15(targetSdk 35)부터는 edge-to-edge가 강제되어
+        // window.statusBarColor / navigationBarColor 설정이 no-op이 됨.
+        // (구버전 호환을 위해 값 자체는 계속 지정함)
         window.statusBarColor = statusBarColor.toArgb()
         window.navigationBarColor = navigationBarColor.toArgb()
 
         controller.isAppearanceLightStatusBars = darkIcons
         controller.isAppearanceLightNavigationBars = darkIcons
+
+        // 위 색상 지정이 no-op인 기기에서, OS가 자동으로 그려주는 반투명 명암 보정 스크림이
+        // 이전 화면(Login 등)에서 남은 색을 반영해 잔상처럼 비치는 것을 막기 위해 비활성화함.
+        // (isStatusBarContrastEnforced/isNavigationBarContrastEnforced는 API 29+)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            window.isStatusBarContrastEnforced = false
+            window.isNavigationBarContrastEnforced = false
+        }
     }
 }

--- a/feature/curation/src/main/java/com/linku/curation/navigation/CurationGraph.kt
+++ b/feature/curation/src/main/java/com/linku/curation/navigation/CurationGraph.kt
@@ -9,7 +9,6 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
 import com.linku.curation.ui.CurationScreen
-import com.linku.design.util.WhiteSystemBars
 import com.linku.curation.ui.monthly.MonthlyCurationScreen
 import com.linku.curation.ui.screen.CurationKeywordDetailScreen
 import com.linku.curation.ui.screen.CurationKeywordLinksScreen
@@ -40,7 +39,7 @@ fun NavGraphBuilder.curationGraph(
     ) {
         composable("curation_list") {
             showNavBar(true)
-            WhiteSystemBars()
+            // 상태바/내비게이션 바는 MainScreen(app 모듈)에서 공통으로 흰색 처리함.
 
             CurationScreen(
                 nickname = nickname,

--- a/feature/file/src/main/java/com/linku/file/FileApp.kt
+++ b/feature/file/src/main/java/com/linku/file/FileApp.kt
@@ -14,7 +14,6 @@ import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.linku.design.util.WhiteSystemBars
 import com.linku.file.ui.link.SaveLinkResultScreen
 import com.linku.file.viewmodel.edit.state.EditStateViewModel
 import com.linku.file.viewmodel.folder.state.FolderStateViewModel
@@ -23,7 +22,10 @@ import com.linku.file.viewmodel.folder.state.FolderStateViewModel
 fun FileApp(
     fileViewModel: FileViewModel = hiltViewModel(),
     editStateViewModel:EditStateViewModel = viewModel(),
-    folderStateViewModel: FolderStateViewModel = viewModel()
+    folderStateViewModel: FolderStateViewModel = viewModel(),
+    // FileScreen의 그라데이션 상단바가 상태바까지 이어져 보이는 동안 true를 넘겨서
+    // 상태바 글자/아이콘을 흰색으로 바꿈. 다른 화면(상세 등)으로 넘어가면 자동으로 false.
+    onLightStatusBarIconsChange: (Boolean) -> Unit = {}
 ) {
     val context = LocalContext.current
     val navController = rememberNavController()
@@ -33,7 +35,7 @@ fun FileApp(
         navController.navigate("savelinkresult/${id}")
     }
 
-    WhiteSystemBars()
+    // 상태바/내비게이션 바는 MainScreen(app 모듈)에서 공통으로 흰색 처리함.
 
     NavHost(
         navController = navController,
@@ -45,7 +47,8 @@ fun FileApp(
             FileScreen(
                 fileViewModel = fileViewModel,
                 editStateViewModel = editStateViewModel,
-                folderStateViewModel = folderStateViewModel
+                folderStateViewModel = folderStateViewModel,
+                onLightStatusBarIconsChange = onLightStatusBarIconsChange
             )
         }
 

--- a/feature/file/src/main/java/com/linku/file/FileApp.kt
+++ b/feature/file/src/main/java/com/linku/file/FileApp.kt
@@ -22,10 +22,7 @@ import com.linku.file.viewmodel.folder.state.FolderStateViewModel
 fun FileApp(
     fileViewModel: FileViewModel = hiltViewModel(),
     editStateViewModel:EditStateViewModel = viewModel(),
-    folderStateViewModel: FolderStateViewModel = viewModel(),
-    // FileScreen의 그라데이션 상단바가 상태바까지 이어져 보이는 동안 true를 넘겨서
-    // 상태바 글자/아이콘을 흰색으로 바꿈. 다른 화면(상세 등)으로 넘어가면 자동으로 false.
-    onLightStatusBarIconsChange: (Boolean) -> Unit = {}
+    folderStateViewModel: FolderStateViewModel = viewModel()
 ) {
     val context = LocalContext.current
     val navController = rememberNavController()
@@ -47,8 +44,7 @@ fun FileApp(
             FileScreen(
                 fileViewModel = fileViewModel,
                 editStateViewModel = editStateViewModel,
-                folderStateViewModel = folderStateViewModel,
-                onLightStatusBarIconsChange = onLightStatusBarIconsChange
+                folderStateViewModel = folderStateViewModel
             )
         }
 

--- a/feature/file/src/main/java/com/linku/file/FileScreen.kt
+++ b/feature/file/src/main/java/com/linku/file/FileScreen.kt
@@ -36,6 +36,7 @@ import com.linku.design.modifier.noRippleClickable
 import com.linku.design.theme.color.CategoryColorStyle
 import com.linku.design.theme.linkuColors
 import com.linku.design.top.search.SearchBarTopSheet
+import com.linku.design.util.LocalStatusBarDarkIcons
 import com.linku.file.ui.bottom.sheet.BottomFolderEditBottomSheet
 import com.linku.file.ui.bottom.sheet.LinkCategorizationBottomSheet
 import com.linku.file.ui.bottom.sheet.NewBottomFolderBottomSheet
@@ -56,16 +57,17 @@ import kotlinx.coroutines.launch
 fun FileScreen(
     fileViewModel: FileViewModel = hiltViewModel(),
     editStateViewModel:EditStateViewModel = viewModel(),
-    folderStateViewModel: FolderStateViewModel = viewModel(),
-    onLightStatusBarIconsChange: (Boolean) -> Unit = {}
+    folderStateViewModel: FolderStateViewModel = viewModel()
 ) {
     val colors = MaterialTheme.linkuColors
 
     // 상단 그라데이션 헤더가 상태바까지 이어져 보이므로 흰 아이콘이 대비가 더 잘 됨.
+    // MainApp을 거치지 않고 MainScreen이 제공한 상태를 직접 읽고 씀.
     // 이 화면을 벗어나면(상세 화면 등으로 이동) 자동으로 원래대로(검정) 복귀.
+    val statusBarDarkIcons = LocalStatusBarDarkIcons.current
     DisposableEffect(Unit) {
-        onLightStatusBarIconsChange(true)
-        onDispose { onLightStatusBarIconsChange(false) }
+        statusBarDarkIcons.value = false
+        onDispose { statusBarDarkIcons.value = true }
     }
 
     Log.d("FileScreen", "FileScreen")

--- a/feature/file/src/main/java/com/linku/file/FileScreen.kt
+++ b/feature/file/src/main/java/com/linku/file/FileScreen.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -55,9 +56,17 @@ import kotlinx.coroutines.launch
 fun FileScreen(
     fileViewModel: FileViewModel = hiltViewModel(),
     editStateViewModel:EditStateViewModel = viewModel(),
-    folderStateViewModel: FolderStateViewModel = viewModel()
+    folderStateViewModel: FolderStateViewModel = viewModel(),
+    onLightStatusBarIconsChange: (Boolean) -> Unit = {}
 ) {
     val colors = MaterialTheme.linkuColors
+
+    // 상단 그라데이션 헤더가 상태바까지 이어져 보이므로 흰 아이콘이 대비가 더 잘 됨.
+    // 이 화면을 벗어나면(상세 화면 등으로 이동) 자동으로 원래대로(검정) 복귀.
+    DisposableEffect(Unit) {
+        onLightStatusBarIconsChange(true)
+        onDispose { onLightStatusBarIconsChange(false) }
+    }
 
     Log.d("FileScreen", "FileScreen")
     // 한 번만 데이터 로딩 (최초 진입 시)

--- a/feature/home/src/main/java/com/linku/home/HomeApp.kt
+++ b/feature/home/src/main/java/com/linku/home/HomeApp.kt
@@ -11,7 +11,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.linku.design.util.WhiteSystemBars
 import com.linku.home.screen.AlarmScreen
 import com.linku.home.screen.HomeScreen
 import com.linku.home.viewmodel.AlarmViewModel
@@ -34,7 +33,7 @@ fun HomeApp(
     // HomeApp에서 만들어 주입한다.
     val alarmViewModel: AlarmViewModel = hiltViewModel()
 
-    WhiteSystemBars()
+    // 상태바/내비게이션 바는 MainScreen(app 모듈)에서 공통으로 흰색 처리함.
 
 //    // === 감정/상황 키 → 서버 ID 매핑 ===
 //    fun emotionKeyToId(key: String): Long = when (key) {

--- a/feature/login/src/main/java/com/linku/login/navigation/LoginApp.kt
+++ b/feature/login/src/main/java/com/linku/login/navigation/LoginApp.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -56,7 +57,10 @@ fun LoginApp(
     onLoginSuccess: () -> Unit,
     onAutoLoginSuccess: () -> Unit,
     onAutoLoginFail: () -> Unit,
-    loginViewModel: LoginViewModel
+    loginViewModel: LoginViewModel,
+    // 그라데이션 배경(AnimatedLoginScreen/LoginScreen)이 보이는 동안에만 true를 전달해서
+    // 상위(MainScreen)의 흰색 상태바 스크림을 끔. 그 외 로그인 하위 화면은 흰 상태바가 기본.
+    onEdgeToEdgeChange: (Boolean) -> Unit = {}
 ) {
     val navController = rememberNavController()
 
@@ -112,6 +116,13 @@ fun LoginApp(
 
                 LaunchedEffect(skipAnimation) {
                     if (skipAnimation) parentEntry.savedStateHandle["skip_login_animation"] = false
+                }
+
+                // AnimatedLoginScreen/LoginScreen은 그라데이션 배경이 상태바까지 비치는
+                // edge-to-edge 화면. 이 화면을 벗어나면(email_login 등으로 이동) 자동으로 꺼짐.
+                DisposableEffect(Unit) {
+                    onEdgeToEdgeChange(true)
+                    onDispose { onEdgeToEdgeChange(false) }
                 }
 
                 AnimatedLoginScreen(
@@ -398,6 +409,12 @@ fun LoginApp(
 
                 BackHandler(enabled = showTermsSheet) {
                     entry.savedStateHandle["show_terms_sheet"] = false
+                }
+
+                // 이 화면도 그라데이션 배경이 상태바까지 비치는 edge-to-edge 화면.
+                DisposableEffect(Unit) {
+                    onEdgeToEdgeChange(true)
+                    onDispose { onEdgeToEdgeChange(false) }
                 }
 
                 LoginScreen(

--- a/feature/login/src/main/java/com/linku/login/ui/screen/email/EmailLoginScreen.kt
+++ b/feature/login/src/main/java/com/linku/login/ui/screen/email/EmailLoginScreen.kt
@@ -78,6 +78,7 @@ fun EmailLoginScreen(
     val isPreview = LocalInspectionMode.current
 
     // 로그인 입력 화면 진입 시 시스템 바 복구
+    // (색상/아이콘 밝기는 MainScreen이 edgeToEdgeSystemBars 상태를 보고 공통 처리함)
     DisposableEffect(Unit) {
         if (!isPreview && systemBarController != null) {
             systemBarController.setSystemBarMode(SystemBarMode.VISIBLE)

--- a/feature/mypage/src/main/java/com/linku/mypage/MyPageApp.kt
+++ b/feature/mypage/src/main/java/com/linku/mypage/MyPageApp.kt
@@ -10,7 +10,6 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
-import com.linku.design.util.WhiteSystemBars
 import com.linku.mypage.screen.AccountSettingScreen
 import com.linku.mypage.screen.AlarmSettingScreen
 import com.linku.mypage.screen.ChangePasswordScreen
@@ -39,7 +38,7 @@ fun MyPageApp(
     // MyPageApp에서 만들어 주입한다.
     val notificationViewModel: NotificationViewModel = hiltViewModel()
 
-    WhiteSystemBars()
+    // 상태바/내비게이션 바는 MainScreen(app 모듈)에서 공통으로 흰색 처리함.
 
     // 로그인 시 발급받은 userId 를 보관하고 있다면 그 값을 사용
     // 화면 진입 시 최신 데이터 한 번 긁어오기


### PR DESCRIPTION
## Summary
- Android 15(targetSdk 35)부터 edge-to-edge가 강제되면서 `window.statusBarColor`/`navigationBarColor` 지정이 no-op이 되고, `DesignSystemBars`(Compose)와 `SystemBarController`(Activity, 상태 캐시 보유)가 같은 Window를 서로 모르게 건드리는 이중 구조까지 겹쳐 화면마다 상태바/내비게이션 바 색상이 제각각으로 보이던 문제(#122)를 수정했습니다.
- 화면마다 개별적으로 `WhiteSystemBars()`를 호출하던 방식을 걷어내고, `MainScreen`(app 모듈) 한 곳에서 신규 `EdgeToEdgeSystemBars()` 프리셋으로 아이콘 밝기·바 표시 여부만 공통 제어하도록 통합했습니다. 배경색은 강제로 칠하지 않고 각 화면 콘텐츠가 시스템 바 뒤까지 자연스럽게 이어져 보이도록(edge-to-edge) 했습니다.
- Splash·로그인 그라데이션 화면(AnimatedLoginScreen/LoginScreen)만 기존처럼 자체적으로 immersive 상태를 관리하도록 예외 처리했고, File 탭은 상단 그라데이션 헤더가 떠 있는 동안만 상태바 아이콘을 흰색으로 전환하도록 별도 상태로 연결했습니다.
- `MainActivity`의 `SystemBarController.setSystemBarMode` 조기 반환 캐시(다른 경로에서 상태가 바뀌어도 갱신되지 않아 복구 호출이 씹히던 버그)를 제거했습니다.
- Android 15+에서 deprecated된 API(`statusBarColor`/`navigationBarColor`/`isStatusBarContrastEnforced` 등)는 구버전(API 34 이하, 스와이프로 바를 잠깐 꺼낼 때) 호환을 위해 의도적으로 유지하고 `@Suppress("DEPRECATION")`으로 정리했습니다.
- 더 이상 호출되지 않는 `WhiteSystemBars()`/`TransparentSystemBars()`/`DarkSystemBars()`는 삭제하지 않고 주석 처리(다크모드 대응 시 재사용 예정).

## Test plan
- [x] `:app:assembleDebug` 전체 빌드 통과 확인
- [ ] 실기기(Android 15 권장)로 스플래시 → 로그인 → 홈 → 파일/큐레이션/마이 전환 흐름에서 상태바·내비게이션 바 색상 및 아이콘 밝기 육안 확인
- [ ] File 탭 진입/이탈 시 상태바 아이콘 색 전환 확인

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **개선 사항**
  - 화면 전환 시 상태 표시줄/내비게이션 바가 edge-to-edge로 콘텐츠와 자연스럽게 연동됩니다.
  - 화면에 맞춰 상태 표시줄 아이콘 명암(밝음/어두움)이 자동 조정됩니다.
  - 로그인 일부 화면에서 배경이 상태바까지 확장되며, 화면을 떠나면 원래 설정으로 복원됩니다.
  - 파일 화면에서도 상태 표시줄 아이콘 모드가 정확히 전환됩니다.
  - Android 10 이상에서 대비 효과로 인한 잔상/색상 불일치가 줄어듭니다.
  - 동일 설정을 다시 적용해도 시스템 바 갱신이 안정적으로 유지됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->