### PR TITLE
[Feature]: 로그아웃, 회원탈퇴 API 연동 및 토큰 회수

### DIFF
--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -365,20 +365,6 @@ fun MainApp(
                                 popUpTo("login_root") { inclusive = true }
                                 launchSingleTop = true
                             }
-                        },
-                        onAutoLoginSuccess = {
-                            showNavBar = true
-                            edgeToEdgeSystemBars = false
-                            homeViewModel.refreshAfterLogin()
-                            navigator.navigate(NavigationRoute.Home.route) {
-                                popUpTo(NavigationRoute.Splash.route) { inclusive = true }
-                                launchSingleTop = true
-                            }
-                        },
-                        onAutoLoginFail = {
-                            navigator.navigate("login_root") {
-                                popUpTo(NavigationRoute.Splash.route) { inclusive = true }
-                            }
                         }
                     )
                 }

--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -36,12 +36,12 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navArgument
 import androidx.navigation.navDeepLink
 import com.linku.core.model.auth.AutoLoginState
+import com.linku.core.model.deeplink.DeepLinkType
 import com.linku.core.util.logging.LinkuLog
 import com.linku.core.util.logging.d
 import com.linku.curation.navigation.curationGraph
 import com.linku.curation.viewModel.CurationViewModel
 import com.linku.deeplink.DeepLinkHandlerViewModel
-import com.linku.core.model.deeplink.DeepLinkType
 import com.linku.deeplink.invitationLinkRoute
 import com.linku.design.AlarmAllowDialog
 import com.linku.design.theme.ThemeProvider
@@ -454,11 +454,15 @@ fun MainApp(
                                 // 전역 스택을 지우고 로그인 루트로 이동
                                 viewModel.clearNickname()
                                 navigator.navigate("login_root") {
-                                    // 현재 내비게이션 그래프의 시작점(Splash 등)까지 모두 제거
-                                    popUpTo(navigator.graph.findStartDestination().id) {
+                                    // 그래프 루트까지 백스택 전부 제거.
+                                    // Splash는 로그인 이후 이미 백스택에서 빠져있는 상태라
+                                    // findStartDestination()(Splash)을 popUpTo 타겟으로 쓰면
+                                    // 백스택에서 못 찾아 조용히 no-op 되어(Home/MyPage가 그대로 남음)
+                                    // login_root가 그 위에 얹히기만 하는 문제가 있었음.
+                                    // 그래프 자체의 id는 항상 모든 백스택 엔트리의 조상이라 반드시 제거됨.
+                                    popUpTo(navigator.graph.id) {
                                         inclusive = true
                                     }
-                                    //popUpTo(0) { inclusive = true }
                                     launchSingleTop = true
                                 }
 //                                navigator.navigate(NavigationRoute.Login.route) {

--- a/app/src/main/java/com/linku/MainViewModel.kt
+++ b/app/src/main/java/com/linku/MainViewModel.kt
@@ -8,8 +8,6 @@ import android.net.NetworkRequest
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
-import com.linku.core.model.alarm.AlarmType
-import com.linku.core.repository.AlarmRepository
 import com.linku.core.repository.RecentSearchRepository
 import com.linku.core.repository.UserRepository
 import com.linku.core.usecase.FirstPushAlarmAllowedUseCase
@@ -18,7 +16,6 @@ import com.linku.data.preference.NotificationPreference
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -66,7 +63,7 @@ class MainViewModel @Inject constructor(
 
     // 메인 뷰모델은 액티비티에 속해있어서 앱 종료까지 살아있어서, 로그아웃시에도 닉네임 정보 살아 있을 수 있음. 제거용 구현
     fun clearNickname() {
-        _nickname.value
+        _nickname.value = ""
     }
 
     private val connectivityManager =

--- a/core/src/main/java/com/linku/core/model/LoginResult.kt
+++ b/core/src/main/java/com/linku/core/model/LoginResult.kt
@@ -3,7 +3,7 @@ package com.linku.core.model
 data class LoginResult(
     val userId: Long,
     val accessToken: String, // 널 비허용으로 수정.
-    val refreshToken: String,
+    val refreshToken: String?, // 탈퇴 유예기간(INACTIVE) 계정 로그인 시 서버가 null로 내려줌
     val status: String,
     val inactiveDate: String?
 )

--- a/core/src/main/java/com/linku/core/repository/UserRepository.kt
+++ b/core/src/main/java/com/linku/core/repository/UserRepository.kt
@@ -6,6 +6,9 @@ import com.linku.core.model.UserInfo
 interface UserRepository {
 
     suspend fun deleteUser(reason: String): Boolean
+
+    // 회원 탈퇴 복구 (탈퇴 유예기간 14일 이내 재로그인 시). 성공(서버 호출 성공)했을 때만 true.
+    suspend fun recoverUser(): Boolean
 //
 //    // 닉네임 전용 메서드 추가
 //    suspend fun getNickname(userId: Long): String?

--- a/core/src/main/java/com/linku/core/repository/UserRepository.kt
+++ b/core/src/main/java/com/linku/core/repository/UserRepository.kt
@@ -21,8 +21,8 @@ interface UserRepository {
         interests: List<String>
     ): Result<Unit>
 
-    // 로그아웃
-    suspend fun logout()
+    // 로그아웃. 성공(서버 호출 + 로컬 세션 정리)했을 때만 true.
+    suspend fun logout(): Boolean
 
     // 닉네임만 호출
     suspend fun getNickname(): String?

--- a/core/src/main/java/com/linku/core/repository/UserRepository.kt
+++ b/core/src/main/java/com/linku/core/repository/UserRepository.kt
@@ -5,7 +5,7 @@ import com.linku.core.model.UserInfo
 
 interface UserRepository {
 
-    suspend fun deleteUser(reason: String): Boolean
+    suspend fun deleteUser(reason: String): Result<Unit>
 
     // 회원 탈퇴 복구 (탈퇴 유예기간 14일 이내 재로그인 시). 성공(서버 호출 성공)했을 때만 true.
     suspend fun recoverUser(): Boolean

--- a/data/src/main/java/com/linku/data/api/UserApi.kt
+++ b/data/src/main/java/com/linku/data/api/UserApi.kt
@@ -4,6 +4,7 @@ import com.linku.data.api.dto.BaseResponse
 import com.linku.data.api.dto.user.DeleteUserRequestDTO
 import com.linku.data.api.dto.user.DeleteUserResponseDTO
 import com.linku.data.api.dto.user.NicknameResponseDTO
+import com.linku.data.api.dto.user.RecoverUserResponseDTO
 import com.linku.data.api.dto.user.UpdateUserProfileRequestDTO
 import com.linku.data.api.dto.user.UserInfoResponseDTO
 import retrofit2.http.Body
@@ -48,6 +49,11 @@ interface UserApi {
     suspend fun logout(
         @Query("deviceId") deviceId: String
     ): BaseResponse<*> // result {}
+
+    // 회원 탈퇴 복구 (계정 활성화) - 탈퇴 유예기간(14일) 내 재로그인 시 호출.
+    // 로그인 응답의 accessToken(purpose=RECOVER)이 Authorization 헤더로 자동 첨부됨.
+    @POST("users/recover")
+    suspend fun recoverUser(): BaseResponse<RecoverUserResponseDTO>
 
 //    // 로그인
 //    @POST("users/login")

--- a/data/src/main/java/com/linku/data/api/UserApi.kt
+++ b/data/src/main/java/com/linku/data/api/UserApi.kt
@@ -10,6 +10,7 @@ import retrofit2.http.Body
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
+import retrofit2.http.Query
 
 interface UserApi {
 
@@ -41,6 +42,12 @@ interface UserApi {
     suspend fun deleteUser(
         @Body body: DeleteUserRequestDTO
     ): BaseResponse<DeleteUserResponseDTO>
+
+    // 로그아웃 - 요청의 deviceId에 해당하는 현재 디바이스 세션만 로그아웃
+    @POST("auth/logout")
+    suspend fun logout(
+        @Query("deviceId") deviceId: String
+    ): BaseResponse<*> // result {}
 
 //    // 로그인
 //    @POST("users/login")

--- a/data/src/main/java/com/linku/data/api/dto/auth/login/email/LoginResponseDTO.kt
+++ b/data/src/main/java/com/linku/data/api/dto/auth/login/email/LoginResponseDTO.kt
@@ -15,8 +15,9 @@ data class LoginResponseDTO (
     @field:Json(name = "accessToken")
     val accessToken: String,
 
+    // 탈퇴 유예기간(INACTIVE) 계정은 서버가 refreshToken을 null로 내려줌 (복구 전용 accessToken만 발급)
     @field:Json(name = "refreshToken")
-    val refreshToken: String,
+    val refreshToken: String?,
 
     @field:Json(name = "status")
     val status: String = "",

--- a/data/src/main/java/com/linku/data/api/dto/auth/login/social/SocialLoginResponseDTO.kt
+++ b/data/src/main/java/com/linku/data/api/dto/auth/login/social/SocialLoginResponseDTO.kt
@@ -12,9 +12,13 @@ data class SocialLoginResponseDTO(
     @field:Json(name = "accessToken")
     val accessToken: String,
 
+    // 탈퇴 유예기간(INACTIVE) 계정은 서버가 refreshToken을 null로 내려줌 (복구 전용 accessToken만 발급)
     @field:Json(name = "refreshToken")
-    val refreshToken: String,
+    val refreshToken: String?,
 
     @field:Json(name = "status")
     val status: String?,
+
+    @field:Json(name = "inactiveDate")
+    val inactiveDate: String? = "",
 )

--- a/data/src/main/java/com/linku/data/api/dto/user/RecoverUserResponseDTO.kt
+++ b/data/src/main/java/com/linku/data/api/dto/user/RecoverUserResponseDTO.kt
@@ -1,0 +1,25 @@
+package com.linku.data.api.dto.user
+
+import com.squareup.moshi.Json
+import com.squareup.moshi.JsonClass
+import java.time.OffsetDateTime
+
+@JsonClass(generateAdapter = true)
+data class RecoverUserResponseDTO(
+
+    @field:Json(name = "userId")
+    val userId: Long,
+
+    @field:Json(name = "nickname")
+    val nickname: String,
+
+    @field:Json(name = "createdAt")
+    val createdAt: OffsetDateTime,
+
+    @field:Json(name = "status")
+    val status: String,
+
+    @field:Json(name = "inactiveDate")
+    val inactiveDate: OffsetDateTime? = null
+
+)

--- a/data/src/main/java/com/linku/data/implementation/preference/AuthPreferenceImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/preference/AuthPreferenceImpl.kt
@@ -32,6 +32,9 @@ class AuthPreferenceImpl @Inject constructor(
         val DEVICE_ID = stringPreferencesKey("device_id")
         val DEVICE_TYPE = stringPreferencesKey("device_type")
         val NICKNAME = stringPreferencesKey("nickname")
+
+        // 로그아웃(clear) 시에도 남겨둘 키. 디바이스 정보와 마지막 로그인 수단은 유저 세션이 아니라 기기/이력 정보라 보존함.
+        val PRESERVED_ON_CLEAR = setOf(DEVICE_ID, DEVICE_TYPE, LOGIN_TYPE)
     }
 
     override suspend fun initDeviceInfo(deviceId: String, deviceType: String) {
@@ -113,9 +116,13 @@ class AuthPreferenceImpl @Inject constructor(
         }
     }
 
+    // 로그아웃 시 토큰/유저ID/닉네임 등 세션 정보만 지우고,
+    // 디바이스 정보와 마지막으로 로그인한 수단(카카오/구글/이메일)은 남겨 다음 로그인 화면에서 "최근 로그인" 표시에 사용함.
     override suspend fun clear() {
         context.authDataStore.edit { prefs ->
-            prefs.clear()
+            prefs.asMap().keys
+                .filterNot { it in Keys.PRESERVED_ON_CLEAR }
+                .forEach { prefs.remove(it) }
             prefs[Keys.LOGGED_IN] = false
         }
     }

--- a/data/src/main/java/com/linku/data/implementation/preference/AuthPreferenceImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/preference/AuthPreferenceImpl.kt
@@ -13,6 +13,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import java.io.IOException
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -83,8 +84,13 @@ class AuthPreferenceImpl @Inject constructor(
         context.authDataStore.data.map { it[Keys.DEVICE_TYPE] ?: "PHONE" }.first()
 
     override suspend fun getLoginType(): LoginType {
-        val name =
-            context.authDataStore.data.map { it[Keys.LOGIN_TYPE] }.first() ?: return LoginType.NONE
+        // DataStore 파일 읽기 실패(IOException)까지 NONE으로 흡수 - 로그인 화면의 "최근 로그인" 조회가
+        // 이 예외 하나로 부모 코루틴까지 깨지면 안 되므로.
+        val name = try {
+            context.authDataStore.data.map { it[Keys.LOGIN_TYPE] }.first()
+        } catch (e: IOException) {
+            null
+        } ?: return LoginType.NONE
         return runCatching { LoginType.valueOf(name) }.getOrElse { LoginType.NONE }
     }
 

--- a/data/src/main/java/com/linku/data/implementation/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/AuthRepositoryImpl.kt
@@ -239,16 +239,31 @@ class AuthRepositoryImpl @Inject constructor(
         ).map { response ->
             val currentStatus = response.status?.uppercase() ?: "ACTIVE"
 
-            if (currentStatus == "ACTIVE") {
-                authPreference.saveTokens(
-                    accessToken = response.accessToken,
-                    refreshToken = response.refreshToken,
-                    userId = response.userId,
-                    loginType = LoginType.KAKAO
-                )
-                Log.d(TAG, "[카카오 로그인] ACTIVE 상태 - 토큰 저장 완료")
-            } else if (currentStatus == "TEMP") {
-                Log.d(TAG, "[카카오 로그인] TEMP 상태 - 추가 입력 필요 (토큰 저장 스킵)")
+            when (currentStatus) {
+                "ACTIVE" -> {
+                    authPreference.saveTokens(
+                        accessToken = response.accessToken,
+                        refreshToken = response.refreshToken,
+                        userId = response.userId,
+                        loginType = LoginType.KAKAO
+                    )
+                    Log.d(TAG, "[카카오 로그인] ACTIVE 상태 - 토큰 저장 완료")
+                }
+
+                "TEMP" -> {
+                    Log.d(TAG, "[카카오 로그인] TEMP 상태 - 추가 입력 필요 (토큰 저장 스킵)")
+                }
+
+                "INACTIVE" -> {
+                    // 탈퇴 유예기간 계정. 복구 API(users/recover) 호출에 필요한 토큰을 미리 저장해둠.
+                    authPreference.saveTokens(
+                        accessToken = response.accessToken,
+                        refreshToken = response.refreshToken,
+                        userId = response.userId,
+                        loginType = LoginType.KAKAO
+                    )
+                    Log.d(TAG, "[카카오 로그인] INACTIVE 상태 - 복구용 토큰 저장 완료")
+                }
             }
 
             Log.d(TAG, "[카카오 로그인 성공] status=$currentStatus")
@@ -258,7 +273,7 @@ class AuthRepositoryImpl @Inject constructor(
                 accessToken = response.accessToken,
                 refreshToken = response.refreshToken,
                 status = currentStatus,
-                inactiveDate = ""
+                inactiveDate = response.inactiveDate
             )
         }
     }
@@ -283,16 +298,31 @@ class AuthRepositoryImpl @Inject constructor(
         ).map { response ->
             val currentStatus = response.status?.uppercase() ?: "ACTIVE"
 
-            if (currentStatus == "ACTIVE") {
-                authPreference.saveTokens(
-                    accessToken = response.accessToken,
-                    refreshToken = response.refreshToken,
-                    userId = response.userId,
-                    loginType = LoginType.GOOGLE
-                )
-                Log.d(TAG, "[구글 로그인] ACTIVE 상태 - 토큰 저장 완료")
-            } else if (currentStatus == "TEMP") {
-                Log.d(TAG, "[구글 로그인] TEMP 상태 - 추가 입력 필요 (토큰 저장 스킵)")
+            when (currentStatus) {
+                "ACTIVE" -> {
+                    authPreference.saveTokens(
+                        accessToken = response.accessToken,
+                        refreshToken = response.refreshToken,
+                        userId = response.userId,
+                        loginType = LoginType.GOOGLE
+                    )
+                    Log.d(TAG, "[구글 로그인] ACTIVE 상태 - 토큰 저장 완료")
+                }
+
+                "TEMP" -> {
+                    Log.d(TAG, "[구글 로그인] TEMP 상태 - 추가 입력 필요 (토큰 저장 스킵)")
+                }
+
+                "INACTIVE" -> {
+                    // 탈퇴 유예기간 계정. 복구 API(users/recover) 호출에 필요한 토큰을 미리 저장해둠.
+                    authPreference.saveTokens(
+                        accessToken = response.accessToken,
+                        refreshToken = response.refreshToken,
+                        userId = response.userId,
+                        loginType = LoginType.GOOGLE
+                    )
+                    Log.d(TAG, "[구글 로그인] INACTIVE 상태 - 복구용 토큰 저장 완료")
+                }
             }
 
             Log.d(TAG, "[구글 로그인 성공] status=$currentStatus")
@@ -302,7 +332,7 @@ class AuthRepositoryImpl @Inject constructor(
                 accessToken = response.accessToken,
                 refreshToken = response.refreshToken,
                 status = currentStatus,
-                inactiveDate = ""
+                inactiveDate = response.inactiveDate
             )
         }.onFailure { e ->
             Log.e(TAG, "[구글 로그인 실패] ${e.message}")

--- a/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
@@ -63,13 +63,22 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     override suspend fun deleteUser(reason: String): Result<Unit> {
-        return safeApiCallUnit {
-            serverApi.deleteUser(DeleteUserRequestDTO(reason))
-        }.onSuccess {
-            // 탈퇴 성공 시에만 로컬 세션 제거. 실패하면 계정은 그대로라 로그인 상태를 유지해야 함.
+        val result = safeApiCallUnit { serverApi.deleteUser(DeleteUserRequestDTO(reason)) }
+        if (result.isFailure) {
+            Log.e(TAG, "[회원 탈퇴 실패] ${result.exceptionOrNull()?.message}")
+            return result
+        }
+
+        // 탈퇴 성공 시에만 로컬 세션 제거. 실패하면 계정은 그대로라 로그인 상태를 유지해야 함.
+        // DataStore I/O 예외가 여기서 나면 Result 계약 밖으로 새지 않도록 잡아서 failure로 변환함.
+        return try {
             authPreference.clear()
-        }.onFailure {
-            Log.e(TAG, "[회원 탈퇴 실패] ${it.message}")
+            result
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "[회원 탈퇴 세션 정리 실패] ${e.message}")
+            Result.failure(e)
         }
     }
 

--- a/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
@@ -92,8 +92,16 @@ class UserRepositoryImpl @Inject constructor(
 
     // logout
     override suspend fun logout() {
+        val deviceId = authPreference.getDeviceId()
+        Log.d(TAG, "[로그아웃 시도] deviceId=$deviceId")
+
+        safeApiCallUnit {
+            serverApi.logout(deviceId)
+        }.onFailure { e ->
+            Log.e(TAG, "[로그아웃 API 실패] ${e.message}")
+        }
+
         authPreference.clear()
-        //clearAuthData()
         Log.d(TAG, "로그아웃 완료")
     }
 

--- a/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
@@ -64,6 +64,8 @@ class UserRepositoryImpl @Inject constructor(
     override suspend fun deleteUser(reason: String): Boolean {
         return try {
             serverApi.deleteUser(DeleteUserRequestDTO(reason))
+            // 탈퇴 성공 시에만 로컬 세션 제거. 실패하면 계정은 그대로라 로그인 상태를 유지해야 함.
+            authPreference.clear()
             true
         } catch (e: Exception) {
             false
@@ -90,19 +92,20 @@ class UserRepositoryImpl @Inject constructor(
         }.getOrNull()?.nickname
     }
 
-    // logout
-    override suspend fun logout() {
+    // logout. deleteUser()와 동일하게 서버 호출이 성공했을 때만 로컬 세션을 지움.
+    override suspend fun logout(): Boolean {
         val deviceId = authPreference.getDeviceId()
         Log.d(TAG, "[로그아웃 시도] deviceId=$deviceId")
 
-        safeApiCallUnit {
-            serverApi.logout(deviceId)
-        }.onFailure { e ->
-            Log.e(TAG, "[로그아웃 API 실패] ${e.message}")
+        return try {
+            safeApiCallUnit { serverApi.logout(deviceId) }.getOrThrow()
+            authPreference.clear()
+            Log.d(TAG, "로그아웃 완료")
+            true
+        } catch (e: Exception) {
+            Log.e(TAG, "[로그아웃 실패] ${e.message}")
+            false
         }
-
-        authPreference.clear()
-        Log.d(TAG, "로그아웃 완료")
     }
 
     companion object {

--- a/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
@@ -77,6 +77,19 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
+    override suspend fun recoverUser(): Boolean {
+        return try {
+            // BaseResponse.isSuccess까지 확인. HTTP 2xx여도 응답 바디상 실패일 수 있어 getOrThrow()로 걸러냄.
+            safeApiCallUnit { serverApi.recoverUser() }.getOrThrow()
+            true
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "[계정 복구 실패] ${e.message}")
+            false
+        }
+    }
+
 //    // BaseResponse<UserInfoDTO> 반환 → withAuth
 //    override suspend fun getNickname(userId: Long): String? {
 //        return try {

--- a/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
@@ -11,6 +11,7 @@ import com.linku.data.api.dto.user.UpdateUserProfileRequestDTO
 import com.linku.data.api.safeApiCall
 import com.linku.data.api.safeApiCallUnit
 import com.linku.data.preference.AuthPreference
+import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 
 class UserRepositoryImpl @Inject constructor(
@@ -63,11 +64,15 @@ class UserRepositoryImpl @Inject constructor(
 
     override suspend fun deleteUser(reason: String): Boolean {
         return try {
-            serverApi.deleteUser(DeleteUserRequestDTO(reason))
+            // BaseResponse.isSuccess까지 확인. HTTP 2xx여도 응답 바디상 실패일 수 있어 getOrThrow()로 걸러냄.
+            safeApiCallUnit { serverApi.deleteUser(DeleteUserRequestDTO(reason)) }.getOrThrow()
             // 탈퇴 성공 시에만 로컬 세션 제거. 실패하면 계정은 그대로라 로그인 상태를 유지해야 함.
             authPreference.clear()
             true
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
+            Log.e(TAG, "[회원 탈퇴 실패] ${e.message}")
             false
         }
     }
@@ -94,14 +99,17 @@ class UserRepositoryImpl @Inject constructor(
 
     // logout. deleteUser()와 동일하게 서버 호출이 성공했을 때만 로컬 세션을 지움.
     override suspend fun logout(): Boolean {
-        val deviceId = authPreference.getDeviceId()
-        Log.d(TAG, "[로그아웃 시도] deviceId=$deviceId")
-
         return try {
+            // getDeviceId() 실패도 try 안에서 잡아야 false로 이어져 onError 처리가 정상 동작함.
+            val deviceId = authPreference.getDeviceId()
+            Log.d(TAG, "[로그아웃 시도] deviceId=$deviceId")
+
             safeApiCallUnit { serverApi.logout(deviceId) }.getOrThrow()
             authPreference.clear()
             Log.d(TAG, "로그아웃 완료")
             true
+        } catch (e: CancellationException) {
+            throw e
         } catch (e: Exception) {
             Log.e(TAG, "[로그아웃 실패] ${e.message}")
             false

--- a/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
@@ -62,18 +62,14 @@ class UserRepositoryImpl @Inject constructor(
         }
     }
 
-    override suspend fun deleteUser(reason: String): Boolean {
-        return try {
-            // BaseResponse.isSuccess까지 확인. HTTP 2xx여도 응답 바디상 실패일 수 있어 getOrThrow()로 걸러냄.
-            safeApiCallUnit { serverApi.deleteUser(DeleteUserRequestDTO(reason)) }.getOrThrow()
+    override suspend fun deleteUser(reason: String): Result<Unit> {
+        return safeApiCallUnit {
+            serverApi.deleteUser(DeleteUserRequestDTO(reason))
+        }.onSuccess {
             // 탈퇴 성공 시에만 로컬 세션 제거. 실패하면 계정은 그대로라 로그인 상태를 유지해야 함.
             authPreference.clear()
-            true
-        } catch (e: CancellationException) {
-            throw e
-        } catch (e: Exception) {
-            Log.e(TAG, "[회원 탈퇴 실패] ${e.message}")
-            false
+        }.onFailure {
+            Log.e(TAG, "[회원 탈퇴 실패] ${it.message}")
         }
     }
 

--- a/design/src/main/java/com/linku/design/modal/ModalWindow.kt
+++ b/design/src/main/java/com/linku/design/modal/ModalWindow.kt
@@ -80,7 +80,8 @@ fun ModalWindow(
  *
  * @param visible 모달 창의 표시 여부. true일 때 화면에 나타납니다.
  * @param onOkay '확인' 버튼을 클릭했을 때 실행될 콜백 함수.
- * @param onDismiss 모달을 닫아야 할 때(취소 버튼 클릭 또는 외부 영역 클릭 시) 실행될 콜백 함수.
+ * @param onDismiss 모달을 닫아야 할 때(외부 영역 클릭 시, 또는 두 버튼 클릭 이후) 실행될 콜백 함수. 순수 UI 처리(모달 숨김)만 담당해야 하며, 두 버튼 클릭 시 공통으로 호출되므로 여기에 버튼별 부수 효과를 넣으면 안 됨.
+ * @param onNegativeClick 취소 버튼을 클릭했을 때 실행될 콜백 함수. 기본값은 null이며, 이 경우 취소 버튼은 [onDismiss]만 호출하는 기존 동작을 유지함. 취소 버튼도 확인 버튼과 별개의 의미 있는 동작(예: 서버 호출)을 수행해야 하는 경우에만 지정할 것.
  * @param positiveText 확인 버튼에 표시될 텍스트.
  * @param negativeText 취소 버튼에 표시될 텍스트.
  * @param title 모달 상단에 표시될 강조된 제목 텍스트.
@@ -94,6 +95,7 @@ fun ModalWindow(
     visible: Boolean,
     onOkay: () -> Unit = {},
     onDismiss: () -> Unit,
+    onNegativeClick: (() -> Unit)? = null,
     positiveText: String,
     negativeText: String,
     title: String,
@@ -115,7 +117,10 @@ fun ModalWindow(
             ModalSecondaryButton(
                 modifier = Modifier.weight(1f),
                 text = negativeText,
-                onClick = onDismiss
+                onClick = {
+                    onNegativeClick?.invoke()
+                    onDismiss()
+                }
             )
             ModalPrimaryButton(
                 modifier = Modifier.weight(1f),

--- a/feature/login/src/main/java/com/linku/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/linku/login/LoginScreen.kt
@@ -6,6 +6,7 @@ package com.linku.login
 import android.content.Context
 import android.util.Log
 import android.widget.Toast
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -14,11 +15,14 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.navigationBarsPadding
+import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -32,6 +36,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Devices
@@ -283,8 +288,9 @@ fun LoginScreen(
         ) {
 
             // 카카오
-            SocialLoginButton(
+            SocialLoginButtonWithRecentBadge(
                 type = LoginType.KAKAO,
+                recentLoginType = uiState.recentLoginType,
                 onClick = {
                     if (buttonsEnabled) handleKakaoLogin(context, viewModel)
                     //약관 화면에서 중복 로그인 방지.
@@ -293,13 +299,14 @@ fun LoginScreen(
 
 
             // 구글
-            SocialLoginButton(
+            SocialLoginButtonWithRecentBadge(
                 type = LoginType.GOOGLE,
+                recentLoginType = uiState.recentLoginType,
                 onClick = {
-                    if (!buttonsEnabled) return@SocialLoginButton
+                    if (!buttonsEnabled) return@SocialLoginButtonWithRecentBadge
                     val activity = context.findActivity() ?: run {
                         Toast.makeText(context, "간편 로그인 실패. 다시 시도해주세요!", Toast.LENGTH_SHORT).show()
-                        return@SocialLoginButton
+                        return@SocialLoginButtonWithRecentBadge
                     }
                     scope.launch {
                         try {
@@ -313,14 +320,44 @@ fun LoginScreen(
             )
 
             // 이메일 기존 그대로 유지.
-            SocialLoginButton(
+            SocialLoginButtonWithRecentBadge(
                 type = LoginType.EMAIL,
+                recentLoginType = uiState.recentLoginType,
                 onClick = {
                     //navigator.navigate("email_login")
                     if (buttonsEnabled) {
                         onNavigateToEmailLogin()
                     }
                 }
+            )
+        }
+    }
+}
+
+/**
+ * 소셜 로그인 버튼 위에 마지막으로 로그인했던 수단을 알려주는 "최근 로그인" 말풍선을 겹쳐 보여줍니다.
+ *
+ * @param type 이 버튼이 나타내는 로그인 수단.
+ * @param recentLoginType 사용자가 마지막으로 로그인했던 수단. [type]과 일치할 때만 말풍선이 노출됩니다.
+ */
+@Composable
+private fun SocialLoginButtonWithRecentBadge(
+    type: LoginType,
+    recentLoginType: LoginType,
+    onClick: () -> Unit
+) {
+    Box(modifier = Modifier.fillMaxWidth()) {
+        SocialLoginButton(type = type, onClick = onClick)
+
+        if (recentLoginType == type) {
+            Image(
+                painter = painterResource(id = R.drawable.img_recent_login),
+                contentDescription = "최근 로그인",
+                modifier = Modifier
+                    .align(Alignment.TopEnd)
+                    .offset(x = (-7).scaler, y = (-20).scaler)
+                    .width(100.scaler)
+                    .height(42.scaler)
             )
         }
     }

--- a/feature/login/src/main/java/com/linku/login/LoginScreen.kt
+++ b/feature/login/src/main/java/com/linku/login/LoginScreen.kt
@@ -50,6 +50,7 @@ import com.kakao.sdk.common.model.ClientError
 import com.kakao.sdk.common.model.ClientErrorCause
 import com.kakao.sdk.user.UserApiClient
 import com.linku.core.model.auth.LoginType
+import com.linku.design.modal.ModalWindow
 import com.linku.design.theme.LinkuPreview
 import com.linku.design.theme.linkuColors
 import com.linku.design.util.DesignSystemBars
@@ -329,6 +330,27 @@ fun LoginScreen(
                         onNavigateToEmailLogin()
                     }
                 }
+            )
+        }
+
+        // 탈퇴 유예기간(INACTIVE) 계정으로 소셜 로그인 시도 시 노출되는 복구 확인 모달
+        ModalWindow(
+            visible = uiState.showRecoverModal,
+            onOkay = { viewModel.keepWithdrawn() },
+            onNegativeClick = { viewModel.recoverAccount() },
+            onDismiss = { viewModel.dismissRecoverModal() },
+            positiveText = "탈퇴 유지",
+            negativeText = "계정 복구",
+            title = "탈퇴 처리 중인 계정입니다.",
+            isLogoDimmed = true
+        ) {
+            Text(
+                text = "지금 로그인하면 계정이 즉시 복구됩니다.\n14일이 지나면 모든 정보가 삭제돼요.",
+                fontSize = 15.sp,
+                lineHeight = 22.sp,
+                fontWeight = FontWeight(400),
+                color = colorTheme.gray[600],
+                textAlign = TextAlign.Center
             )
         }
     }

--- a/feature/login/src/main/java/com/linku/login/navigation/LoginApp.kt
+++ b/feature/login/src/main/java/com/linku/login/navigation/LoginApp.kt
@@ -55,8 +55,6 @@ import com.linku.login.viewmodel.state.LoginUiEffect
 @Composable
 fun LoginApp(
     onLoginSuccess: () -> Unit,
-    onAutoLoginSuccess: () -> Unit,
-    onAutoLoginFail: () -> Unit,
     loginViewModel: LoginViewModel,
     // 그라데이션 배경(AnimatedLoginScreen/LoginScreen)이 보이는 동안에만 true를 전달해서
     // 상위(MainScreen)의 흰색 상태바 스크림을 끔. 그 외 로그인 하위 화면은 흰 상태바가 기본.
@@ -64,13 +62,15 @@ fun LoginApp(
 ) {
     val navController = rememberNavController()
 
-    // 채널 effect는 오직 LoginApp에서만
+    // 채널 effect는 오직 LoginApp에서만.
+    // 자동 로그인 성공/실패는 Splash가 loginViewModel.autoLoginState(StateFlow)를 직접 관찰해 라우팅하므로
+    // 여기서는 다루지 않음 - LoginApp은 자동 로그인 시점엔 아직 컴포즈되지 않아 이 채널로 보내면
+    // 이벤트가 버퍼에 쌓였다가, 로그아웃/탈퇴 후 LoginApp이 뒤늦게 재구성될 때 그 오래된 이벤트를
+    // 받아 엉뚱하게 홈으로 되돌아가는 문제가 있었음.
     LaunchedEffect(Unit) {
         loginViewModel.sideEffect.collect { effect ->
             when (effect) {
                 is LoginUiEffect.LoginSuccess -> onLoginSuccess()
-                is LoginUiEffect.AutoLoginSuccess -> onAutoLoginSuccess()
-                is LoginUiEffect.AutoLoginFail -> onAutoLoginFail()
             }
         }
     }

--- a/feature/login/src/main/java/com/linku/login/navigation/LoginApp.kt
+++ b/feature/login/src/main/java/com/linku/login/navigation/LoginApp.kt
@@ -10,6 +10,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
@@ -62,6 +65,10 @@ fun LoginApp(
 ) {
     val navController = rememberNavController()
 
+    // 탈퇴 유예기간(INACTIVE) 계정 복구 모달 표시 여부. 단순 1회성 이벤트라 uiState가 아닌
+    // sideEffect(ShowRecoverModal)로 받아서 여기서 remember 상태로만 관리함.
+    var showRecoverModal by remember { mutableStateOf(false) }
+
     // 채널 effect는 오직 LoginApp에서만.
     // 자동 로그인 성공/실패는 Splash가 loginViewModel.autoLoginState(StateFlow)를 직접 관찰해 라우팅하므로
     // 여기서는 다루지 않음 - LoginApp은 자동 로그인 시점엔 아직 컴포즈되지 않아 이 채널로 보내면
@@ -71,6 +78,7 @@ fun LoginApp(
         loginViewModel.sideEffect.collect { effect ->
             when (effect) {
                 is LoginUiEffect.LoginSuccess -> onLoginSuccess()
+                is LoginUiEffect.ShowRecoverModal -> showRecoverModal = true
             }
         }
     }
@@ -161,6 +169,8 @@ fun LoginApp(
 
                 EmailLoginScreen(
                     loginViewModel = loginViewModel,
+                    showRecoverModal = showRecoverModal,
+                    onDismissRecoverModal = { showRecoverModal = false },
                     onSignUpClick = {
                         parentEntry.savedStateHandle["show_terms_sheet"] = true
                     },

--- a/feature/login/src/main/java/com/linku/login/ui/screen/email/EmailLoginScreen.kt
+++ b/feature/login/src/main/java/com/linku/login/ui/screen/email/EmailLoginScreen.kt
@@ -58,6 +58,8 @@ import com.linku.login.viewmodel.state.LoginUiState
 @Composable
 fun EmailLoginScreen(
     loginViewModel: LoginViewModel? = null,
+    showRecoverModal: Boolean = false,
+    onDismissRecoverModal: () -> Unit = {},
     onSignUpClick: () -> Unit,
     onResetPasswordClick: () -> Unit,
     onLoginSuccess: () -> Unit = {}
@@ -241,10 +243,16 @@ fun EmailLoginScreen(
 
         // 탈퇴 유예기간(INACTIVE) 계정으로 로그인 시도 시 노출되는 복구 확인 모달
         ModalWindow(
-            visible = uiState.showRecoverModal,
-            onOkay = { loginViewModel?.keepWithdrawn() },
-            onNegativeClick = { loginViewModel?.recoverAccount() },
-            onDismiss = { loginViewModel?.dismissRecoverModal() },
+            visible = showRecoverModal,
+            onOkay = {
+                loginViewModel?.keepWithdrawn()
+                onDismissRecoverModal()
+            },
+            onNegativeClick = {
+                loginViewModel?.recoverAccount()
+                onDismissRecoverModal()
+            },
+            onDismiss = { onDismissRecoverModal() },
             positiveText = "탈퇴 유지",
             negativeText = "계정 복구",
             title = "탈퇴 처리 중인 계정입니다.",

--- a/feature/login/src/main/java/com/linku/login/ui/screen/email/EmailLoginScreen.kt
+++ b/feature/login/src/main/java/com/linku/login/ui/screen/email/EmailLoginScreen.kt
@@ -252,7 +252,10 @@ fun EmailLoginScreen(
                 loginViewModel?.recoverAccount()
                 onDismissRecoverModal()
             },
-            onDismiss = { onDismissRecoverModal() },
+            onDismiss = {
+                loginViewModel?.dismissRecoverModal()
+                onDismissRecoverModal()
+            },
             positiveText = "탈퇴 유지",
             negativeText = "계정 복구",
             title = "탈퇴 처리 중인 계정입니다.",

--- a/feature/login/src/main/java/com/linku/login/ui/screen/email/EmailLoginScreen.kt
+++ b/feature/login/src/main/java/com/linku/login/ui/screen/email/EmailLoginScreen.kt
@@ -44,6 +44,7 @@ import com.linku.core.model.SystemBarMode
 import com.linku.core.model.auth.LoginState
 import com.linku.core.system.SystemBarController
 import com.linku.design.component.GradientButtonCore
+import com.linku.design.modal.ModalWindow
 import com.linku.design.modifier.noRippleClickable
 import com.linku.design.theme.LinkuPreview
 import com.linku.design.theme.linkuColors
@@ -236,6 +237,29 @@ fun EmailLoginScreen(
                         }
                 )
             }
+        }
+
+        // 탈퇴 유예기간(INACTIVE) 계정으로 로그인 시도 시 노출되는 복구 확인 모달
+        ModalWindow(
+            visible = uiState.showRecoverModal,
+            onOkay = { loginViewModel?.keepWithdrawn() },
+            onNegativeClick = { loginViewModel?.recoverAccount() },
+            onDismiss = { loginViewModel?.dismissRecoverModal() },
+            positiveText = "탈퇴 유지",
+            negativeText = "계정 복구",
+            title = "탈퇴 처리 중인 계정입니다.",
+            isLogoDimmed = true
+        ) {
+            Text(
+                text = "지금 로그인하면 계정이 즉시 복구됩니다.\n14일이 지나면 모든 정보가 삭제돼요.",
+                style = TextStyle(
+                    fontSize = 15.sp,
+                    lineHeight = 22.sp,
+                    fontWeight = FontWeight(400),
+                    color = colorTheme.gray[600],
+                    textAlign = TextAlign.Center
+                )
+            )
         }
     }
 }

--- a/feature/login/src/main/java/com/linku/login/viewmodel/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/LoginViewModel.kt
@@ -10,6 +10,7 @@ import com.linku.core.model.auth.LoginErrorType
 import com.linku.core.model.auth.LoginState
 import com.linku.core.model.auth.LoginType
 import com.linku.core.repository.AuthRepository
+import com.linku.core.repository.UserRepository
 import com.linku.data.api.toLoginErrorType
 import com.linku.data.preference.AuthPreference
 import com.linku.login.mvi.MviContainer
@@ -28,6 +29,7 @@ import kotlin.coroutines.cancellation.CancellationException
 open class LoginViewModel @Inject constructor(
     application: Application,
     private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
     private val authPreference: AuthPreference,
 ) : AndroidViewModel(application),
     MviContainer<LoginUiState, LoginUiEffect> by mviContainer(LoginUiState()) {
@@ -84,9 +86,31 @@ open class LoginViewModel @Inject constructor(
                 )
                 Log.d(TAG, "인증 토큰 및 유저 ID 저장 완료 (ID: ${loginResult.userId})")
 
-                // 성공 상태 -> MainApp에서 isLoggedIn Flow 변화를 감지해 홈으로 이동하게 함.
-                updateState { copy(loginState = LoginState.Success(loginResult)) }
-                postSideEffect(LoginUiEffect.LoginSuccess)
+                if (loginResult.status == "INACTIVE") {
+                    // 탈퇴 유예기간 계정 -> 홈으로 보내지 않고 복구 여부를 묻는 모달을 띄움.
+                    Log.d(TAG, "탈퇴 유예기간 계정 감지 - 복구 모달 노출")
+                    // 인증 자체는 이미 끝났으므로 입력해둔 이메일/비밀번호는 화면에 남겨두지 않음
+                    // (로그아웃 후 다시 이 화면에 들어와도 이전 입력값이 남아있지 않도록).
+                    updateState {
+                        copy(
+                            loginState = LoginState.Idle,
+                            showRecoverModal = true,
+                            email = "",
+                            password = ""
+                        )
+                    }
+                } else {
+                    // 성공 상태 -> MainApp에서 isLoggedIn Flow 변화를 감지해 홈으로 이동하게 함.
+                    // 인증에 사용한 이메일/비밀번호도 화면에서 지움 (재진입 시 이전 입력값 노출 방지).
+                    updateState {
+                        copy(
+                            loginState = LoginState.Success(loginResult),
+                            email = "",
+                            password = ""
+                        )
+                    }
+                    postSideEffect(LoginUiEffect.LoginSuccess)
+                }
 
             } catch (exception: CancellationException) {
                 throw exception
@@ -95,6 +119,48 @@ open class LoginViewModel @Inject constructor(
                 updateState { copy(loginState = LoginState.Error(exception.toLoginErrorType())) }
             }
         }
+    }
+
+    /**
+     * 복구 모달에서 "계정 복구"를 선택했을 때 호출됨. 로그인 응답으로 이미 저장된
+     * 복구 전용 accessToken을 이용해 `users/recover`를 호출하고, 성공하면 정상 로그인과
+     * 동일하게 홈으로 이동시킴.
+     */
+    fun recoverAccount() {
+        viewModelScope.launch {
+            val recovered = userRepository.recoverUser()
+            if (recovered) {
+                Log.d(TAG, "계정 복구 성공")
+                updateState { copy(showRecoverModal = false) }
+                postSideEffect(LoginUiEffect.LoginSuccess)
+            } else {
+                Log.e(TAG, "계정 복구 실패 (유예기간 만료 등)")
+                // 복구 실패 시 계정은 여전히 비활성 상태이므로 임시 저장된 세션을 정리함.
+                authPreference.clear()
+                updateState {
+                    copy(
+                        showRecoverModal = false,
+                        loginState = LoginState.Error(LoginErrorType.INACTIVE_User_Error)
+                    )
+                }
+            }
+        }
+    }
+
+    /**
+     * 복구 모달에서 "탈퇴 유지"를 선택했을 때 호출됨. 로그인 응답으로 임시 저장해둔
+     * 세션(복구 전용 토큰)을 지우고 로그인 화면에 그대로 남김.
+     */
+    fun keepWithdrawn() {
+        viewModelScope.launch {
+            authPreference.clear()
+            updateState { copy(showRecoverModal = false) }
+        }
+    }
+
+    /** 복구 모달을 순수 UI적으로만 닫음(외부 영역 클릭 등). 세션은 건드리지 않음. */
+    fun dismissRecoverModal() {
+        updateState { copy(showRecoverModal = false) }
     }
 
     fun tryAutoLogin() {
@@ -107,26 +173,22 @@ open class LoginViewModel @Inject constructor(
 
                 if (!isAlreadyLoggedIn) {
                     _autoLoginState.value = AutoLoginState.Failed
-                    postSideEffect(LoginUiEffect.AutoLoginFail)
                     return@launch
                 }
 
                 Log.d(TAG, "자동 로그인 성공")
                 _autoLoginState.value = AutoLoginState.Success
-                postSideEffect(LoginUiEffect.AutoLoginSuccess)
 
             } catch (e: ApiError.Auth.TokenExpired) {
                 // 이 경우만 logout
                 Log.e(TAG, "자동 로그인 실패: 토큰 만료")
                 authPreference.clear()
                 _autoLoginState.value = AutoLoginState.Failed
-                postSideEffect(LoginUiEffect.AutoLoginFail)
 
             } catch (e: Exception) {
                 // 나머지는 절대 logout 하지 않음
                 Log.e(TAG, "자동 로그인 실패: ${e.message}")
                 _autoLoginState.value = AutoLoginState.Failed
-                postSideEffect(LoginUiEffect.AutoLoginFail)
             }
         }
     }

--- a/feature/login/src/main/java/com/linku/login/viewmodel/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/LoginViewModel.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.linku.core.error.ApiError
+import com.linku.core.model.LoginResult
 import com.linku.core.model.auth.AutoLoginState
 import com.linku.core.model.auth.LoginErrorType
 import com.linku.core.model.auth.LoginState
@@ -36,6 +37,10 @@ open class LoginViewModel @Inject constructor(
 
     private val _autoLoginState = MutableStateFlow<AutoLoginState>(AutoLoginState.Idle)
     val autoLoginState: StateFlow<AutoLoginState> = _autoLoginState
+
+    // INACTIVE 로그인 응답을 복구 모달이 뜬 동안 임시로 들고 있는 값. "부활" 성공 시에만
+    // saveTokens()로 정식 세션 저장에 사용하고, 그 전까지는 AuthPreference에 LOGGED_IN을 세팅하지 않음.
+    private var pendingRecoverLoginResult: LoginResult? = null
 
     fun onEmailChanged(email: String) {
         updateState { copy(email = email) }
@@ -78,17 +83,17 @@ open class LoginViewModel @Inject constructor(
                     deviceType = deviceType
                 ).getOrThrow() //TODO :  .fold() 형식으로 수정하기
 
-                authPreference.saveTokens(
-                    accessToken = loginResult.accessToken,
-                    refreshToken = loginResult.refreshToken,
-                    userId = loginResult.userId,
-                    loginType = LoginType.EMAIL
-                )
-                Log.d(TAG, "인증 토큰 및 유저 ID 저장 완료 (ID: ${loginResult.userId})")
-
                 if (loginResult.status == "INACTIVE") {
                     // 탈퇴 유예기간 계정 -> 홈으로 보내지 않고 복구 여부를 묻는 모달을 띄움.
+                    // LOGGED_IN을 세팅하면 다음 실행 시 tryAutoLogin()이 서버 상태를 재확인하지 않고
+                    // 로컬 플래그만 보고 바로 홈으로 보내버리는 문제가 있어, 여기서는 saveTokens() 대신
+                    // updateAccessToken()으로 복구 API 호출용 토큰만 임시 저장함.
                     Log.d(TAG, "탈퇴 유예기간 계정 감지 - 복구 모달 노출")
+                    pendingRecoverLoginResult = loginResult
+                    authPreference.updateAccessToken(
+                        loginResult.accessToken,
+                        loginResult.refreshToken
+                    )
                     // 인증 자체는 이미 끝났으므로 입력해둔 이메일/비밀번호는 화면에 남겨두지 않음
                     // (로그아웃 후 다시 이 화면에 들어와도 이전 입력값이 남아있지 않도록).
                     updateState {
@@ -100,6 +105,14 @@ open class LoginViewModel @Inject constructor(
                     }
                     postSideEffect(LoginUiEffect.ShowRecoverModal)
                 } else {
+                    authPreference.saveTokens(
+                        accessToken = loginResult.accessToken,
+                        refreshToken = loginResult.refreshToken,
+                        userId = loginResult.userId,
+                        loginType = LoginType.EMAIL
+                    )
+                    Log.d(TAG, "인증 토큰 및 유저 ID 저장 완료 (ID: ${loginResult.userId})")
+
                     // 성공 상태 -> MainApp에서 isLoggedIn Flow 변화를 감지해 홈으로 이동하게 함.
                     // 인증에 사용한 이메일/비밀번호도 화면에서 지움 (재진입 시 이전 입력값 노출 방지).
                     updateState {
@@ -129,12 +142,22 @@ open class LoginViewModel @Inject constructor(
     fun recoverAccount() {
         viewModelScope.launch {
             val recovered = userRepository.recoverUser()
-            if (recovered) {
+            val pendingResult = pendingRecoverLoginResult
+            pendingRecoverLoginResult = null
+
+            if (recovered && pendingResult != null) {
                 Log.d(TAG, "계정 복구 성공")
+                // 복구가 확정된 시점에만 정식 세션(LOGGED_IN=true)으로 저장함.
+                authPreference.saveTokens(
+                    accessToken = pendingResult.accessToken,
+                    refreshToken = pendingResult.refreshToken,
+                    userId = pendingResult.userId,
+                    loginType = LoginType.EMAIL
+                )
                 postSideEffect(LoginUiEffect.LoginSuccess)
             } else {
                 Log.e(TAG, "계정 복구 실패 (유예기간 만료 등)")
-                // 복구 실패 시 계정은 여전히 비활성 상태이므로 임시 저장된 세션을 정리함.
+                // 복구 실패 시 계정은 여전히 비활성 상태이므로 임시 저장된 토큰을 정리함.
                 authPreference.clear()
                 updateState { copy(loginState = LoginState.Error(LoginErrorType.INACTIVE_User_Error)) }
             }
@@ -142,11 +165,21 @@ open class LoginViewModel @Inject constructor(
     }
 
     /**
-     * 복구 모달에서 "탈퇴 유지"를 선택했을 때 호출됨. 로그인 응답으로 임시 저장해둔
-     * 세션(복구 전용 토큰)을 지우고 로그인 화면에 그대로 남김.
+     * 복구 모달에서 "탈퇴 유지"를 선택했을 때 호출됨. 임시 저장해둔 복구 전용 토큰을
+     * 지우고 로그인 화면에 그대로 남김.
      */
     fun keepWithdrawn() {
         viewModelScope.launch {
+            pendingRecoverLoginResult = null
+            authPreference.clear()
+        }
+    }
+
+    /** 복구 모달을 아무 선택 없이 닫았을 때(외부 영역 클릭 등) 호출됨. 임시 저장된 복구 전용
+     * 토큰이 계속 남아있으면 이후 다른 API 호출에 잘못 붙을 수 있어 함께 정리함. */
+    fun dismissRecoverModal() {
+        viewModelScope.launch {
+            pendingRecoverLoginResult = null
             authPreference.clear()
         }
     }

--- a/feature/login/src/main/java/com/linku/login/viewmodel/LoginViewModel.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/LoginViewModel.kt
@@ -94,11 +94,11 @@ open class LoginViewModel @Inject constructor(
                     updateState {
                         copy(
                             loginState = LoginState.Idle,
-                            showRecoverModal = true,
                             email = "",
                             password = ""
                         )
                     }
+                    postSideEffect(LoginUiEffect.ShowRecoverModal)
                 } else {
                     // 성공 상태 -> MainApp에서 isLoggedIn Flow 변화를 감지해 홈으로 이동하게 함.
                     // 인증에 사용한 이메일/비밀번호도 화면에서 지움 (재진입 시 이전 입력값 노출 방지).
@@ -131,18 +131,12 @@ open class LoginViewModel @Inject constructor(
             val recovered = userRepository.recoverUser()
             if (recovered) {
                 Log.d(TAG, "계정 복구 성공")
-                updateState { copy(showRecoverModal = false) }
                 postSideEffect(LoginUiEffect.LoginSuccess)
             } else {
                 Log.e(TAG, "계정 복구 실패 (유예기간 만료 등)")
                 // 복구 실패 시 계정은 여전히 비활성 상태이므로 임시 저장된 세션을 정리함.
                 authPreference.clear()
-                updateState {
-                    copy(
-                        showRecoverModal = false,
-                        loginState = LoginState.Error(LoginErrorType.INACTIVE_User_Error)
-                    )
-                }
+                updateState { copy(loginState = LoginState.Error(LoginErrorType.INACTIVE_User_Error)) }
             }
         }
     }
@@ -154,13 +148,7 @@ open class LoginViewModel @Inject constructor(
     fun keepWithdrawn() {
         viewModelScope.launch {
             authPreference.clear()
-            updateState { copy(showRecoverModal = false) }
         }
-    }
-
-    /** 복구 모달을 순수 UI적으로만 닫음(외부 영역 클릭 등). 세션은 건드리지 않음. */
-    fun dismissRecoverModal() {
-        updateState { copy(showRecoverModal = false) }
     }
 
     fun tryAutoLogin() {

--- a/feature/login/src/main/java/com/linku/login/viewmodel/SocialAuthViewModel.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/SocialAuthViewModel.kt
@@ -12,6 +12,7 @@ import com.linku.core.model.auth.LoginType
 import com.linku.core.model.auth.NicknameCheckState
 import com.linku.core.model.auth.Purpose
 import com.linku.core.repository.AuthRepository
+import com.linku.core.repository.UserRepository
 import com.linku.data.preference.AuthPreference
 import com.linku.login.mvi.MviContainer
 import com.linku.login.mvi.mviContainer
@@ -38,6 +39,7 @@ import javax.inject.Inject
 @HiltViewModel
 class SocialAuthViewModel @Inject constructor(
     private val authRepository: AuthRepository,
+    private val userRepository: UserRepository,
     private val authPreference: AuthPreference
 ) : ViewModel(),
     MviContainer<SocialAuthUiState, SocialAuthUiEffect> by mviContainer(SocialAuthUiState()) {
@@ -129,17 +131,66 @@ class SocialAuthViewModel @Inject constructor(
     }
 
     /**
-     * 인증 성공 후 전달받은 회원의 가입 영속 상태(TEMP / ACTIVE)를 판별하여 화면 흐름(Side Effect)을 제어합니다.
+     * 인증 성공 후 전달받은 회원의 가입 영속 상태(TEMP / ACTIVE / INACTIVE)를 판별하여 화면 흐름(Side Effect)을 제어합니다.
      */
     private suspend fun handleLoginRoute(result: LoginResult) {
-        if (result.status == "TEMP") {
-            Log.d(TAG, "신규 TEMP 회원 감지 -> 로컬 세션 초기화 및 온보딩 입력 플로우 지시")
-            authPreference.clear()
-            postSideEffect(SocialAuthUiEffect.NavigateToAdditionalInfo(result))
-        } else {
-            Log.d(TAG, "기존 ACTIVE 회원 감지 -> 로컬 토큰 자동 동기화 완료 상태로 홈 진입 지시")
-            postSideEffect(SocialAuthUiEffect.NavigateToHome(result))
+        when (result.status) {
+            "TEMP" -> {
+                Log.d(TAG, "신규 TEMP 회원 감지 -> 로컬 세션 초기화 및 온보딩 입력 플로우 지시")
+                authPreference.clear()
+                postSideEffect(SocialAuthUiEffect.NavigateToAdditionalInfo(result))
+            }
+
+            "INACTIVE" -> {
+                // 탈퇴 유예기간 계정 -> 홈으로 보내지 않고 복구 여부를 묻는 모달을 띄움.
+                Log.d(TAG, "탈퇴 유예기간 계정 감지 -> 복구 모달 노출")
+                updateState { copy(showRecoverModal = true, pendingLoginResult = result) }
+            }
+
+            else -> {
+                Log.d(TAG, "기존 ACTIVE 회원 감지 -> 로컬 토큰 자동 동기화 완료 상태로 홈 진입 지시")
+                postSideEffect(SocialAuthUiEffect.NavigateToHome(result))
+            }
         }
+    }
+
+    /**
+     * 복구 모달에서 "계정 복구"를 선택했을 때 호출됨. 로그인 응답으로 이미 저장된
+     * 복구 전용 accessToken을 이용해 `users/recover`를 호출하고, 성공하면 정상 로그인과
+     * 동일하게 홈으로 이동시킴.
+     */
+    fun recoverAccount() {
+        viewModelScope.launch {
+            val pendingResult = state.value.pendingLoginResult
+            val recovered = userRepository.recoverUser()
+            updateState { copy(showRecoverModal = false, pendingLoginResult = null) }
+
+            if (recovered && pendingResult != null) {
+                Log.d(TAG, "계정 복구 성공")
+                postSideEffect(SocialAuthUiEffect.NavigateToHome(pendingResult))
+            } else {
+                Log.e(TAG, "계정 복구 실패 (유예기간 만료 등)")
+                // 복구 실패 시 계정은 여전히 비활성 상태이므로 임시 저장된 세션을 정리함.
+                authPreference.clear()
+                postSideEffect(SocialAuthUiEffect.ShowToast("계정 복구에 실패했습니다. 다시 시도해주세요."))
+            }
+        }
+    }
+
+    /**
+     * 복구 모달에서 "탈퇴 유지"를 선택했을 때 호출됨. 로그인 응답으로 임시 저장해둔
+     * 세션(복구 전용 토큰)을 지우고 로그인 화면에 그대로 남김.
+     */
+    fun keepWithdrawn() {
+        viewModelScope.launch {
+            authPreference.clear()
+            updateState { copy(showRecoverModal = false, pendingLoginResult = null) }
+        }
+    }
+
+    /** 복구 모달을 순수 UI적으로만 닫음(외부 영역 클릭 등). 세션은 건드리지 않음. */
+    fun dismissRecoverModal() {
+        updateState { copy(showRecoverModal = false) }
     }
 
     /**

--- a/feature/login/src/main/java/com/linku/login/viewmodel/SocialAuthViewModel.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/SocialAuthViewModel.kt
@@ -56,6 +56,17 @@ class SocialAuthViewModel @Inject constructor(
 
     init {
         observeNicknameQuery()
+        loadRecentLoginType()
+    }
+
+    /**
+     * 로그인 화면에 "최근 로그인" 말풍선을 표시하기 위해 마지막으로 로그인했던 수단을 불러옵니다.
+     */
+    private fun loadRecentLoginType() {
+        viewModelScope.launch {
+            val recentLoginType = authPreference.getLoginType()
+            updateState { copy(recentLoginType = recentLoginType) }
+        }
     }
 
     private fun updateForm(update: (SocialLoginForm) -> SocialLoginForm) {

--- a/feature/login/src/main/java/com/linku/login/viewmodel/state/LoginUiEffect.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/state/LoginUiEffect.kt
@@ -4,6 +4,4 @@ import com.linku.login.mvi.UiSideEffect
 
 internal sealed interface LoginUiEffect : UiSideEffect {
     object LoginSuccess : LoginUiEffect
-    object AutoLoginSuccess : LoginUiEffect
-    object AutoLoginFail : LoginUiEffect
 }

--- a/feature/login/src/main/java/com/linku/login/viewmodel/state/LoginUiEffect.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/state/LoginUiEffect.kt
@@ -4,4 +4,7 @@ import com.linku.login.mvi.UiSideEffect
 
 internal sealed interface LoginUiEffect : UiSideEffect {
     object LoginSuccess : LoginUiEffect
+
+    // 탈퇴 유예기간(INACTIVE) 계정으로 로그인 시도 시 복구 여부를 묻는 모달을 띄우라는 1회성 이벤트
+    object ShowRecoverModal : LoginUiEffect
 }

--- a/feature/login/src/main/java/com/linku/login/viewmodel/state/LoginUiState.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/state/LoginUiState.kt
@@ -9,5 +9,7 @@ import com.linku.login.mvi.UiState
 internal data class LoginUiState(
     val email: String = "",
     val password: String = "",
-    val loginState: LoginState = LoginState.Idle
+    val loginState: LoginState = LoginState.Idle,
+    // 탈퇴 유예기간(INACTIVE) 계정으로 로그인 시도 시 계정 복구 여부를 묻는 모달 표시 여부
+    val showRecoverModal: Boolean = false
 ) : UiState

--- a/feature/login/src/main/java/com/linku/login/viewmodel/state/LoginUiState.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/state/LoginUiState.kt
@@ -9,7 +9,5 @@ import com.linku.login.mvi.UiState
 internal data class LoginUiState(
     val email: String = "",
     val password: String = "",
-    val loginState: LoginState = LoginState.Idle,
-    // 탈퇴 유예기간(INACTIVE) 계정으로 로그인 시도 시 계정 복구 여부를 묻는 모달 표시 여부
-    val showRecoverModal: Boolean = false
+    val loginState: LoginState = LoginState.Idle
 ) : UiState

--- a/feature/login/src/main/java/com/linku/login/viewmodel/state/SocialAuthUiState.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/state/SocialAuthUiState.kt
@@ -1,5 +1,6 @@
 package com.linku.login.viewmodel.state
 
+import com.linku.core.model.LoginResult
 import com.linku.core.model.auth.Gender
 import com.linku.core.model.auth.Interest
 import com.linku.core.model.auth.Job
@@ -16,13 +17,16 @@ import com.linku.login.mvi.UiState
  * @property nicknameCheckState 닉네임 실시간 중복 검증 상태(Idle, Checking, Available, Error)를 나타냅니다.
  * @property error 화면에 표시할 예외 상황 메시지 또는 서버 에러 문구입니다.
  * @property recentLoginType 가장 최근에 로그인했던 수단. 로그인 화면에서 "최근 로그인" 말풍선을 표시하는 데 사용합니다.
+ * @property showRecoverModal 탈퇴 유예기간(INACTIVE) 계정으로 소셜 로그인 시도 시 계정 복구 여부를 묻는 모달 표시 여부입니다.
  */
 internal data class SocialAuthUiState(
     val isLoading: Boolean = false,
     val socialLoginForm: SocialLoginForm = SocialLoginForm(),
     val nicknameCheckState: NicknameCheckState = NicknameCheckState.Idle,
     val error: String? = null,
-    val recentLoginType: LoginType = LoginType.NONE
+    val recentLoginType: LoginType = LoginType.NONE,
+    val showRecoverModal: Boolean = false,
+    val pendingLoginResult: LoginResult? = null
 ) : UiState
 
 internal data class SocialLoginForm(

--- a/feature/login/src/main/java/com/linku/login/viewmodel/state/SocialAuthUiState.kt
+++ b/feature/login/src/main/java/com/linku/login/viewmodel/state/SocialAuthUiState.kt
@@ -3,6 +3,7 @@ package com.linku.login.viewmodel.state
 import com.linku.core.model.auth.Gender
 import com.linku.core.model.auth.Interest
 import com.linku.core.model.auth.Job
+import com.linku.core.model.auth.LoginType
 import com.linku.core.model.auth.NicknameCheckState
 import com.linku.core.model.auth.Purpose
 import com.linku.login.mvi.UiState
@@ -14,12 +15,14 @@ import com.linku.login.mvi.UiState
  * @property socialLoginForm 온보딩 전 과정의 데이터가 누적되는 폼 주머니 객체입니다. (★에러 해결의 핵심)
  * @property nicknameCheckState 닉네임 실시간 중복 검증 상태(Idle, Checking, Available, Error)를 나타냅니다.
  * @property error 화면에 표시할 예외 상황 메시지 또는 서버 에러 문구입니다.
+ * @property recentLoginType 가장 최근에 로그인했던 수단. 로그인 화면에서 "최근 로그인" 말풍선을 표시하는 데 사용합니다.
  */
 internal data class SocialAuthUiState(
     val isLoading: Boolean = false,
     val socialLoginForm: SocialLoginForm = SocialLoginForm(),
     val nicknameCheckState: NicknameCheckState = NicknameCheckState.Idle,
-    val error: String? = null
+    val error: String? = null,
+    val recentLoginType: LoginType = LoginType.NONE
 ) : UiState
 
 internal data class SocialLoginForm(

--- a/feature/mypage/src/main/java/com/linku/mypage/MyPageApp.kt
+++ b/feature/mypage/src/main/java/com/linku/mypage/MyPageApp.kt
@@ -353,10 +353,11 @@ fun MyPageApp(
                                 .makeText(context, "탈퇴 처리가 완료되었습니다.", android.widget.Toast.LENGTH_SHORT)
                                 .show()
 
-                            // 1) 내부(MyPageApp) 스택 정리
-                            navController.popBackStack(route = "mypage", inclusive = true)
-
-                            // 2) 상위 네비게이터로 로그인 이동 요청
+                            // 상위 네비게이터로 로그인 이동 요청.
+                            // onLogoutToLogin()이 외부 백스택 전체(MyPage 탭 포함)를 지우기 때문에
+                            // 이 내부 NavHost도 함께 사라짐 - 별도로 popBackStack("mypage")를 호출하면
+                            // 시작 목적지를 inclusive하게 지우려다 내부 백스택이 비어 예외가 나서
+                            // 바로 아래의 onLogoutToLogin() 호출 자체가 실행되지 못하는 문제가 있었음.
                             onLogoutToLogin()
                         },
                         onError = { msg ->

--- a/feature/mypage/src/main/java/com/linku/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/linku/mypage/MyPageViewModel.kt
@@ -148,15 +148,13 @@ class MyPageViewModel @Inject constructor(
         onError: (String) -> Unit
     ) {
         viewModelScope.launch {
-            try {
-                Log.d("MyPageViewModel", "🚀 회원 탈퇴 중...")
-                userRepository.deleteUser(reason)
+            Log.d("MyPageViewModel", "🚀 회원 탈퇴 중...")
+            val success = userRepository.deleteUser(reason)
+            if (success) {
                 Log.d("MyPageViewModel", "✅ 회원 탈퇴 성공")
-
-
                 onSuccess()
-            } catch (e: Exception) {
-                Log.e("MyPageViewModel", "❌ 회원 탈퇴 실패: ${e.message}")
+            } else {
+                Log.e("MyPageViewModel", "❌ 회원 탈퇴 실패")
                 onError("회원 탈퇴에 실패했습니다.")
             }
         }
@@ -166,11 +164,11 @@ class MyPageViewModel @Inject constructor(
     // TODO: FCM토큰 삭제 API호출
     fun logout(onSuccess: () -> Unit, onError: (String) -> Unit) {
         viewModelScope.launch {
-            try {
-                userRepository.logout()
+            val success = userRepository.logout()
+            if (success) {
                 _uiState.value = MyPageUiState()
                 onSuccess()
-            } catch (e: Exception) {
+            } else {
                 onError("로그아웃에 실패했습니다.")
             }
         }

--- a/feature/mypage/src/main/java/com/linku/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/linku/mypage/MyPageViewModel.kt
@@ -149,14 +149,16 @@ class MyPageViewModel @Inject constructor(
     ) {
         viewModelScope.launch {
             Log.d("MyPageViewModel", "🚀 회원 탈퇴 중...")
-            val success = userRepository.deleteUser(reason)
-            if (success) {
-                Log.d("MyPageViewModel", "✅ 회원 탈퇴 성공")
-                onSuccess()
-            } else {
-                Log.e("MyPageViewModel", "❌ 회원 탈퇴 실패")
-                onError("회원 탈퇴에 실패했습니다.")
-            }
+            userRepository.deleteUser(reason).fold(
+                onSuccess = {
+                    Log.d("MyPageViewModel", "✅ 회원 탈퇴 성공")
+                    onSuccess()
+                },
+                onFailure = { e ->
+                    Log.e("MyPageViewModel", "❌ 회원 탈퇴 실패")
+                    onError("회원 탈퇴에 실패했습니다: ${e.message}")
+                }
+            )
         }
     }
 

--- a/feature/mypage/src/main/java/com/linku/mypage/screen/ServiceQuitScreen.kt
+++ b/feature/mypage/src/main/java/com/linku/mypage/screen/ServiceQuitScreen.kt
@@ -12,11 +12,15 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.BasicTextField
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -24,9 +28,11 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
+import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -65,19 +71,30 @@ fun ServiceQuitScreen(
     val isEtcSelected = selectedReason == "기타"
     val isQuitEnabled = selectedReason != null && isAgreeChecked
 
+    val reasonFocusRequester = remember { FocusRequester() }
+    val keyboardController = LocalSoftwareKeyboardController.current
+
+    // "기타" 선택 시 사유 입력창에 자동으로 커서(포커스) 활성화
+    LaunchedEffect(isEtcSelected) {
+        if (isEtcSelected) {
+            reasonFocusRequester.requestFocus()
+            keyboardController?.show()
+        }
+    }
+
     Box(
         modifier = Modifier.fillMaxSize()
     ) {
         Column(
             modifier = Modifier
-                .fillMaxWidth()
+                .fillMaxSize()
                 .background(colors.white)
-                .padding(horizontal = 20.dp)
         ) {
+            // 헤더는 고정 - 스크롤 영역 밖에 둠
             Box(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(top = 59.dp)
+                    .padding(top = 59.dp, start = 20.dp, end = 20.dp)
                     .height(24.dp)
             ) {
                 Image(
@@ -98,146 +115,158 @@ fun ServiceQuitScreen(
                 )
             }
 
-            Spacer(modifier = Modifier.height(28.25.dp))
-
-            Text(
-                text = "그동안 링큐를 이용해주셔서\n감사합니다.",
-                fontSize = 22.sp,
-                fontWeight = FontWeight.Bold,
-                color = colors.black,
-                modifier = Modifier.padding(horizontal = 4.dp)
-            )
-
-            Spacer(modifier = Modifier.height(5.dp))
-
-            Text(
-                text = "링큐를 이용하며 느끼신 불편함을 공유해주시면\n더욱 발전된 서비스를 제공할 수 있도록 노력하겠습니다.",
-                fontSize = 15.sp,
-                lineHeight = 22.sp,
-                fontWeight = FontWeight.Normal,
-                color = colors.gray[700],
-                modifier = Modifier.padding(horizontal = 4.dp)
-            )
-
-            Spacer(modifier = Modifier.height(24.dp))
-
             Column(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .padding(horizontal = 4.dp)
+                    .weight(1f)
+                    .verticalScroll(rememberScrollState())
+                    .padding(horizontal = 20.dp)
             ) {
-                quitReasons.forEach { reason ->
-                    QuitReasonItem(
-                        text = reason,
-                        selected = selectedReason == reason,
-                        onClick = {
-                            selectedReason = reason
-                            if (reason != "기타") {
-                                reasonText = ""
-                            }
-                        }
-                    )
+                Spacer(modifier = Modifier.height(28.25.dp))
 
-                    Spacer(modifier = Modifier.height(16.dp))
-                }
-            }
-
-            Box(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(14.dp))
-                    .background(colors.gray[100])
-                    .padding(horizontal = 22.dp, vertical = 13.dp)
-            ) {
-                if (reasonText.isBlank()) {
-                    Text(
-                        text = "탈퇴 사유를 적어주세요.",
-                        color = colors.gray[600],
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Normal,
-                    )
-                }
-
-                BasicTextField(
-                    value = reasonText,
-                    onValueChange = {
-                        if (isEtcSelected) {
-                            reasonText = it
-                        }
-                    },
-                    textStyle = TextStyle(
-                        color = colors.black,
-                        fontSize = 14.sp,
-                        fontWeight = FontWeight.Normal,
-                    )
+                Text(
+                    text = "그동안 링큐를 이용해주셔서\n감사합니다.",
+                    fontSize = 22.sp,
+                    fontWeight = FontWeight.Bold,
+                    color = colors.black,
+                    modifier = Modifier.padding(horizontal = 4.dp)
                 )
-            }
 
-            Spacer(modifier = Modifier.height(46.dp))
+                Spacer(modifier = Modifier.height(5.dp))
 
-            Column(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .clip(RoundedCornerShape(15.dp))
-                    .background(colors.gray[100])
-                    .padding(horizontal = 21.dp, vertical = 16.dp),
-            ) {
+                Text(
+                    text = "링큐를 이용하며 느끼신 불편함을 공유해주시면\n더욱 발전된 서비스를 제공할 수 있도록 노력하겠습니다.",
+                    fontSize = 15.sp,
+                    lineHeight = 22.sp,
+                    fontWeight = FontWeight.Normal,
+                    color = colors.gray[700],
+                    modifier = Modifier.padding(horizontal = 4.dp)
+                )
+
+                Spacer(modifier = Modifier.height(24.dp))
+
                 Column(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalAlignment = Alignment.Start
-                ) {
-                    Text(
-                        text = "탈퇴 안내 및 유의사항",
-                        fontSize = 18.sp,
-                        fontWeight = FontWeight.Bold,
-                        color = colors.black
-                    )
-
-                    Spacer(modifier = Modifier.height(4.dp))
-
-                    Text(
-                        text = """
-                                    1. 탈퇴 아이디는 복구와 재사용이 불가합니다.
-                                    2. 삭제된 데이터는 복구되지 않습니다.
-                                    3. 소셜 로그인 회원의 경우 서비스에서 관리하는 모든 정보가 삭제되며, 같은 소셜 아이디로 재가입시 신규 회원으로 가입됩니다.
-                                """.trimIndent(),
-                        fontSize = 15.sp,
-                        lineHeight = 24.sp,
-                        fontWeight = FontWeight.Normal,
-                        color = colors.gray[800]
-                    )
-                }
-
-                Spacer(modifier = Modifier.height(18.dp))
-
-                Row(
                     modifier = Modifier
-                        .align(Alignment.End)
-                        .noRippleClickable { isAgreeChecked = !isAgreeChecked },
-                    horizontalArrangement = Arrangement.Center,
-                    verticalAlignment = Alignment.CenterVertically
+                        .fillMaxWidth()
+                        .padding(horizontal = 4.dp)
                 ) {
-                    Text(
-                        text = "위 안내 사항을 확인했으며 이에 동의합니다.",
-                        fontSize = 15.sp,
-                        fontWeight = FontWeight.Normal,
-                        color = colors.gray[800]
-                    )
+                    quitReasons.forEach { reason ->
+                        QuitReasonItem(
+                            text = reason,
+                            selected = selectedReason == reason,
+                            onClick = {
+                                selectedReason = reason
+                                if (reason != "기타") {
+                                    reasonText = ""
+                                }
+                            }
+                        )
 
-                    Spacer(modifier = Modifier.width(12.dp))
+                        Spacer(modifier = Modifier.height(16.dp))
+                    }
+                }
 
-                    Image(
-                        painter = painterResource(
-                            if (isAgreeChecked) R.drawable.ic_checkbox_checked
-                            else R.drawable.ic_checkbox_empty
-                        ),
-                        contentDescription = null,
-                        modifier = Modifier.noRippleClickable { isAgreeChecked = !isAgreeChecked }
+                Box(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(14.dp))
+                        .background(colors.gray[100])
+                        .padding(horizontal = 22.dp, vertical = 13.dp),
+                    contentAlignment = Alignment.CenterStart
+                ) {
+                    if (reasonText.isEmpty()) {
+                        Text(
+                            text = "탈퇴 사유를 적어주세요.",
+                            color = colors.gray[600],
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Normal,
+                        )
+                    }
+
+                    BasicTextField(
+                        value = reasonText,
+                        onValueChange = {
+                            if (isEtcSelected) {
+                                reasonText = it
+                            }
+                        },
+                        modifier = Modifier.focusRequester(reasonFocusRequester),
+                        textStyle = LocalTextStyle.current.copy(
+                            color = colors.black,
+                            fontSize = 14.sp,
+                            fontWeight = FontWeight.Normal,
+                        )
                     )
                 }
-            }
 
-            Spacer(modifier = Modifier.height(68.dp))
+                Spacer(modifier = Modifier.height(46.dp))
+
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clip(RoundedCornerShape(15.dp))
+                        .background(colors.gray[100])
+                        .padding(horizontal = 21.dp, vertical = 16.dp),
+                ) {
+                    Column(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalAlignment = Alignment.Start
+                    ) {
+                        Text(
+                            text = "탈퇴 안내 및 유의사항",
+                            fontSize = 18.sp,
+                            fontWeight = FontWeight.Bold,
+                            color = colors.black
+                        )
+
+                        Spacer(modifier = Modifier.height(4.dp))
+
+                        Text(
+                            text = """
+                                        1. 탈퇴 아이디는 복구와 재사용이 불가합니다.
+                                        2. 삭제된 데이터는 복구되지 않습니다.
+                                        3. 소셜 로그인 회원의 경우 서비스에서 관리하는 모든 정보가 삭제되며, 같은 소셜 아이디로 재가입시 신규 회원으로 가입됩니다.
+                                    """.trimIndent(),
+                            fontSize = 15.sp,
+                            lineHeight = 24.sp,
+                            fontWeight = FontWeight.Normal,
+                            color = colors.gray[800]
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.height(18.dp))
+
+                    Row(
+                        modifier = Modifier
+                            .align(Alignment.End)
+                            .noRippleClickable { isAgreeChecked = !isAgreeChecked },
+                        horizontalArrangement = Arrangement.Center,
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        Text(
+                            text = "위 안내 사항을 확인했으며 이에 동의합니다.",
+                            fontSize = 15.sp,
+                            fontWeight = FontWeight.Normal,
+                            color = colors.gray[800]
+                        )
+
+                        Spacer(modifier = Modifier.width(12.dp))
+
+                        Image(
+                            painter = painterResource(
+                                if (isAgreeChecked) R.drawable.ic_checkbox_checked
+                                else R.drawable.ic_checkbox_empty
+                            ),
+                            contentDescription = null,
+                            modifier = Modifier.noRippleClickable {
+                                isAgreeChecked = !isAgreeChecked
+                            }
+                        )
+                    }
+                }
+
+                Spacer(modifier = Modifier.height(68.dp))
+            }
         }
 
         Column(

--- a/feature/mypage/src/main/java/com/linku/mypage/screen/ServiceQuitScreen.kt
+++ b/feature/mypage/src/main/java/com/linku/mypage/screen/ServiceQuitScreen.kt
@@ -69,7 +69,9 @@ fun ServiceQuitScreen(
     var isAgreeChecked by remember { mutableStateOf(false) }
 
     val isEtcSelected = selectedReason == "기타"
-    val isQuitEnabled = selectedReason != null && isAgreeChecked
+    // "기타"는 직접 입력한 reasonText를, 그 외엔 선택한 사유 문구 자체를 실제 전송값으로 사용.
+    val effectiveReason = if (isEtcSelected) reasonText else selectedReason.orEmpty()
+    val isQuitEnabled = selectedReason != null && effectiveReason.isNotBlank() && isAgreeChecked
 
     val reasonFocusRequester = remember { FocusRequester() }
     val keyboardController = LocalSoftwareKeyboardController.current
@@ -315,7 +317,7 @@ fun ServiceQuitScreen(
                     onConfirm = {
                         showDialog = false
                         // 실제 탈퇴 로직 호출
-                        onRequestQuit(reasonText)
+                        onRequestQuit(effectiveReason)
                     }
                 )
             }


### PR DESCRIPTION
## 📝 설명
로그아웃 · 회원 탈퇴 API를 연동하고, 두 경우 모두 DataStore에 저장된 사용자 세션(토큰/유저ID/닉네임)을 회수하도록 구현했습니다.

- **로그아웃 API 연동**: `POST auth/logout`을 `UserApi`에 추가(`deviceId`는 query parameter). `UserRepositoryImpl.logout()`이 서버 호출 성공 시에만 `authPreference.clear()`로 로컬 세션을 정리하도록 구현했습니다.
- **회원 탈퇴 후 세션 미정리 버그 수정**: 기존엔 `deleteUser()`가 서버 API만 호출하고 로컬 DataStore는 그대로 남겨둬서, 탈퇴(INACTIVE) 계정으로 다음 실행 시 자동 로그인을 시도하는 문제가 있었습니다. 탈퇴 성공 시에도 `authPreference.clear()`를 호출하도록 수정했습니다.
- **`logout()` / `deleteUser()` 반환 타입 통일**: 둘 다 `Boolean`을 반환해 API 호출이 실패하면 로컬 세션을 지우지 않고, ViewModel에서 실제 성공 여부를 확인해 `onSuccess`/`onError`를 분기하도록 수정했습니다(기존엔 `deleteUser()`의 반환값을 무시하고 항상 성공 처리하던 버그가 있었습니다).
- **`AuthPreference.clear()` 개선**: 세션 정리 시 `deviceId` / `deviceType` / `loginType`(마지막으로 로그인한 수단)은 보존하도록 화이트리스트 기반으로 재구현했습니다. 디바이스 세션 추적이 깨지지 않고, 로그인 화면의 "최근 로그인" 안내에도 사용됩니다.
- **로그인 화면 "최근 로그인" 말풍선 UI 추가** (Figma 반영): 마지막으로 로그인했던 수단(카카오/구글/이메일) 버튼 위에 안내 말풍선을 표시합니다.
- **로그아웃/탈퇴 후 로그인 화면 전환이 안 되던 버그 2건 수정**:
  1. `onLogoutToLogin()`의 `popUpTo` 타겟이 `findStartDestination()`(Splash)이었는데, 로그인 이후엔 Splash가 이미 백스택에서 빠져 있어 no-op이 되고 기존 홈 화면 위에 로그인 화면이 얹히기만 하던 문제 → `popUpTo(navigator.graph.id)`로 수정
  2. 회원 탈퇴 성공 시 MyPageApp 내부 NavHost의 시작 목적지(`"mypage"`)를 inclusive하게 pop하려다 예외가 발생해 바로 다음 줄의 `onLogoutToLogin()`이 실행되지 못하던 문제 → 불필요한 내부 `popBackStack` 호출 제거
- **`MainViewModel.clearNickname()` 버그 수정**: 값을 읽기만 하고 초기화하지 않던 버그(`_nickname.value = ""` 누락)를 수정했습니다.
- **회원 탈퇴 화면(`ServiceQuitScreen`) UI 개선**: 헤더 고정 스크롤 처리, 탈퇴 사유 입력창 세로 중앙 정렬, "기타" 선택 시 입력창 자동 포커스, placeholder가 공백만 입력해도 사라지도록 조건 수정(`isBlank()` → `isEmpty()`)

## 🧪 테스트
- [x] `core`, `data`, `app`, `feature:login`, `feature:mypage` 모듈 `compileDebugKotlin` 통과 확인
- [x] 실기기에서 로그아웃 → 로그인 화면 전환 및 "최근 로그인" 말풍선 노출 확인
- [x] 실기기에서 회원 탈퇴 → 로그인 화면 전환 확인

## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 화면에서 최근 사용한 로그인 수단을 배지로 표시합니다.
  * 탈퇴 유예(INACTIVE) 계정 로그인 시 복구 모달을 제공하고, 복구/유지 선택을 지원합니다.
* **버그 수정**
  * 딥링크/로그인 및 마이페이지 로그아웃 후 네비게이션 백스택 정리가 더 안정적으로 동작합니다.
  * 로그아웃/회원 탈퇴의 성공 여부에 따라 로컬 세션 처리가 일관되게 적용됩니다.
  * 닉네임 초기화가 정상 반영됩니다.
* **UI 개선**
  * ‘기타’ 선택 시 입력 포커스와 키보드가 자동으로 표시됩니다.
  * 탈퇴 화면의 스크롤 및 입력 영역 구성이 개선되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->