### PR TITLE
:zap: 로그인 세션 상태 반영 및 로그아웃 시 로그인 화면으로 이동 처리

### DIFF
--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -300,6 +300,7 @@ fun MainApp(
 
                                 else -> Unit
                             }
+
                         }
 
                         Splash(
@@ -768,6 +769,19 @@ fun MainApp(
 //                    lastBackPressed = now
 //                }
 //            }
+
+            val isLoggedIn by viewModel.isLoggedIn.collectAsStateWithLifecycle()
+            var previousLoggedIn by rememberSaveable { mutableStateOf<Boolean?>(null) }
+
+            LaunchedEffect(isLoggedIn) {
+                if (previousLoggedIn == true && !isLoggedIn) {
+                    navigator.navigate("login_root") {
+                        popUpTo(navigator.graph.id) { inclusive = true }
+                    }
+                }
+                previousLoggedIn = isLoggedIn
+
+            }
         }
     }
 

--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -114,6 +114,19 @@ fun MainApp(
 
     val navigator = rememberNavController()
 
+    val isLoggedIn by viewModel.isLoggedIn.collectAsStateWithLifecycle()
+    var previousLoggedIn by rememberSaveable { mutableStateOf<Boolean?>(null) }
+
+    LaunchedEffect(isLoggedIn) {
+        if (previousLoggedIn == true && isLoggedIn == false) {
+            navigator.navigate("login_root") {
+                popUpTo(navigator.graph.id) { inclusive = true }
+            }
+        }
+        previousLoggedIn = isLoggedIn
+
+    }
+
     // 로그인에서 사용할 뷰모델
     val loginViewModel: LoginViewModel = hiltViewModel()
 
@@ -770,18 +783,6 @@ fun MainApp(
 //                }
 //            }
 
-            val isLoggedIn by viewModel.isLoggedIn.collectAsStateWithLifecycle()
-            var previousLoggedIn by rememberSaveable { mutableStateOf<Boolean?>(null) }
-
-            LaunchedEffect(isLoggedIn) {
-                if (previousLoggedIn == true && !isLoggedIn) {
-                    navigator.navigate("login_root") {
-                        popUpTo(navigator.graph.id) { inclusive = true }
-                    }
-                }
-                previousLoggedIn = isLoggedIn
-
-            }
         }
     }
 

--- a/app/src/main/java/com/linku/MainViewModel.kt
+++ b/app/src/main/java/com/linku/MainViewModel.kt
@@ -45,11 +45,11 @@ class MainViewModel @Inject constructor(
     val nickname: StateFlow<String> = _nickname.asStateFlow()
 
     // 로그인 세션 반영함.
-    val isLoggedIn: StateFlow<Boolean> = authPreference.isLoggedIn
+    val isLoggedIn: StateFlow<Boolean?> = authPreference.isLoggedIn
         .stateIn(
             scope = viewModelScope,
             started = SharingStarted.WhileSubscribed(5000),
-            initialValue = false // 첫 값이 DataStore에서 로드되기 전 임시값
+            initialValue = null // 첫 값이 로그되기 전 아직 모름 상태임. MainApp에서 previousLoggedIn과 비교해 로그아웃 전이면 감지함.
         )
 
     fun fetchNickname() {

--- a/app/src/main/java/com/linku/MainViewModel.kt
+++ b/app/src/main/java/com/linku/MainViewModel.kt
@@ -44,6 +44,14 @@ class MainViewModel @Inject constructor(
     private val _nickname = MutableStateFlow<String>("")
     val nickname: StateFlow<String> = _nickname.asStateFlow()
 
+    // 로그인 세션 반영함.
+    val isLoggedIn: StateFlow<Boolean> = authPreference.isLoggedIn
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5000),
+            initialValue = false // 첫 값이 DataStore에서 로드되기 전 임시값
+        )
+
     fun fetchNickname() {
         viewModelScope.launch {
             // 우선적으로 캐싱 먼저 가져옵니다.(닉네임 변경이 그렇게 많지 않을테니. ui 자연스러움을 위해서 입니다)
@@ -144,8 +152,7 @@ class MainViewModel @Inject constructor(
 
     // 리프레시 토큰 유효성 검사 (컴포저블에서 동기/비동기 흐름 제어를 위해 suspend 함수로 제공)
     suspend fun hasValidRefreshToken(): Boolean {
-        val token = authPreference.getRefreshToken()
-        return !token.isNullOrBlank()
+        return !authPreference.getRefreshToken().isNullOrBlank()
     }
 
     // 푸시 알림 권한 요청 다이얼로그를 최초 1회만 노출


### PR DESCRIPTION
## 📝 설명
> dataStore에 있는 로그인 세션 정보를 flow로 흘러가는 것을 stateFlow를 통해 메인 뷰모델에서 해당 값을 가져오도록 합니다.
메인 앱에서는 이전 로그인했으나 지금 로그인 상태가 풀린 상태의 사용자는 다시 로그인 화면으로 이동하도록 합니다.

## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> #208 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 로그인 상태가 변경되면 앱이 자동으로 로그인 화면으로 이동하고 기존 네비게이션 기록이 정리됩니다.
  * 앱 시작 시 로그인 상태를 안정적으로 확인하도록 개선했습니다.
  * 유효한 로그인 토큰 확인 절차를 간소화했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->