### PR TITLE
fix(auth): 카카오 웹뷰(계정) 로그인 리다이렉트 콜백 미도달 수정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -68,7 +68,12 @@
                     android:path="/open"/>
             </intent-filter>
 
-            <!-- 카카오 로그인 콜백 로컬 프로퍼티에 꼭 각자 디버그 키 넣어주세요. -->
+        </activity>
+
+        <!-- 카카오 로그인 콜백(카카오계정/웹뷰 로그인 리다이렉트). 로컬 프로퍼티에 꼭 각자 디버그 키 넣어주세요. -->
+        <activity
+            android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
+            android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -77,7 +82,6 @@
                     android:scheme="kakao${KAKAO_NATIVE_APP_KEY}"
                     android:host="oauth" />
             </intent-filter>
-
         </activity>
 
         <meta-data


### PR DESCRIPTION
## Summary
- 카카오톡 미설치 환경에서 `loginWithKakaoAccount()`(웹뷰/카카오계정 로그인) 사용 시, OAuth 리다이렉트(`kakao${KAKAO_NATIVE_APP_KEY}://oauth`)가 카카오 SDK의 `AuthCodeHandlerActivity`가 아니라 `MainActivity`에 매칭되어 있어 SDK 콜백이 영영 호출되지 않던 문제를 수정
- 해당 intent-filter를 `MainActivity`에서 제거하고, SDK가 기대하는 `com.kakao.sdk.auth.AuthCodeHandlerActivity`에 정확히 등록
- 앱의 다른 딥링크(`linku://open`, `linku://auth`, `https://{SERVER_HOST}/open`)는 영향 없음

## Test plan
- [ ] 카카오톡 미설치(또는 로그아웃) 기기/에뮬레이터에서 카카오 로그인 버튼 탭 → 웹뷰(카카오계정) 로그인 완료 후 정상적으로 앱으로 복귀 및 로그인 처리되는지 확인
- [ ] 카카오톡 설치된 기기에서 기존 앱 전환 로그인(`loginWithKakaoTalk`) 정상 동작 확인 (회귀 없음)
- [ ] 기존 딥링크(`linku://open`, `linku://auth`, 폴더 공유 https 링크) 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새 기능**
  * 카카오 로그인 후 인증 콜백을 안정적으로 처리하도록 개선했습니다.
  * 로그인 흐름 완료 후 앱으로 정상 복귀할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->