### PR TITLE
🐛 fix(search): 검색 기록 요청 취소 정책 분리

### DIFF
--- a/app/src/main/java/com/linku/search/SearchViewModel.kt
+++ b/app/src/main/java/com/linku/search/SearchViewModel.kt
@@ -27,6 +27,12 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+/** 검색 API 호출을 시작하는 최소 검색어 길이입니다. */
+private const val MIN_SEARCH_LENGTH = 2
+
+/** 검색어 입력 및 API 요청에 허용하는 최대 길이입니다. */
+private const val MAX_SEARCH_LENGTH = 20
+
 @OptIn(ExperimentalCoroutinesApi::class)
 @HiltViewModel
 class SearchViewModel @Inject constructor(
@@ -64,8 +70,20 @@ class SearchViewModel @Inject constructor(
             }
             .cachedIn(viewModelScope)
 
-    private var historyJob: Job? = null
-    private var historyRequestId: Long = 0L
+    /** 이전 조회 결과가 최신 조회 결과를 덮어쓰지 않도록 조회 작업만 관리하는 Job입니다. */
+    private var historyLoadJob: Job? = null
+
+    /** 취소된 이전 조회 결과가 UI에 반영되지 않도록 식별하는 조회 요청 ID입니다. */
+    private var historyLoadRequestId: Long = 0L
+
+    /** 화면 초기화 시 함께 취소할 진행 중인 검색 기록 변경 작업입니다. */
+    private val historyMutationJobs = mutableSetOf<Job>()
+
+    /** 동시에 진행 중인 검색 기록 작업 수입니다. */
+    private var activeHistoryActionCount: Int = 0
+
+    /** 화면 초기화 전에 시작한 작업의 UI 반영을 차단하기 위한 세대 값입니다. */
+    private var historyGeneration: Long = 0L
 
     fun openSearch() {
         resetSearchResults()
@@ -77,117 +95,44 @@ class SearchViewModel @Inject constructor(
     }
 
     fun loadRecentQueries() {
-        val requestId = ++historyRequestId
-        historyJob?.cancel()
-        historyJob = viewModelScope.launch {
-            _uiState.update {
-                it.copy(
-                    isHistoryLoading = true,
-                    errorMessage = null,
+        cancelHistoryLoad()
+        val requestId = historyLoadRequestId
+        historyLoadJob = runHistoryAction(
+            action = recentSearchRepository::getRecentQueries,
+            onSuccess = { state, recentQueries ->
+                state.copy(
+                    recentQueries = recentQueries.map { query ->
+                        RecentSearchItem(
+                            searchHistoryId = query.searchHistoryId,
+                            keyword = query.keyword,
+                        )
+                    },
                 )
-            }
-
-            try {
-                recentSearchRepository.getRecentQueries()
-                    .onSuccess { recentQueries ->
-                        if (historyRequestId == requestId) {
-                            _uiState.update {
-                                it.copy(
-                                    recentQueries = recentQueries.map { query ->
-                                        RecentSearchItem(
-                                            searchHistoryId = query.searchHistoryId,
-                                            keyword = query.keyword,
-                                        )
-                                    },
-                                )
-                            }
-                        }
-                    }
-                    .onFailure { exception ->
-                        if (historyRequestId == requestId) {
-                            _uiState.update { it.copy(errorMessage = exception.message) }
-                        }
-                    }
-            } catch (exception: CancellationException) {
-                throw exception
-            } finally {
-                if (historyRequestId == requestId) {
-                    _uiState.update { it.copy(isHistoryLoading = false) }
-                }
-            }
-        }
+            },
+            canApplyResult = { historyLoadRequestId == requestId },
+        )
     }
 
     fun removeRecentQuery(searchHistoryId: Long) {
-        val requestId = ++historyRequestId
-        historyJob?.cancel()
-        historyJob = viewModelScope.launch {
-            _uiState.update {
-                it.copy(
-                    isHistoryLoading = true,
-                    errorMessage = null,
+        cancelHistoryLoad()
+        runHistoryAction(
+            action = { recentSearchRepository.remove(searchHistoryId) },
+            onSuccess = { state, _ ->
+                state.copy(
+                    recentQueries = state.recentQueries.filterNot { query ->
+                        query.searchHistoryId == searchHistoryId
+                    },
                 )
-            }
-
-            try {
-                recentSearchRepository.remove(searchHistoryId)
-                    .onSuccess {
-                        if (historyRequestId == requestId) {
-                            _uiState.update { state ->
-                                state.copy(
-                                    recentQueries = state.recentQueries.filterNot { query ->
-                                        query.searchHistoryId == searchHistoryId
-                                    },
-                                )
-                            }
-                        }
-                    }
-                    .onFailure { exception ->
-                        if (historyRequestId == requestId) {
-                            _uiState.update { it.copy(errorMessage = exception.message) }
-                        }
-                    }
-            } catch (exception: CancellationException) {
-                throw exception
-            } finally {
-                if (historyRequestId == requestId) {
-                    _uiState.update { it.copy(isHistoryLoading = false) }
-                }
-            }
-        }
+            },
+        ).trackHistoryMutation()
     }
 
     fun clearRecentQueries() {
-        val requestId = ++historyRequestId
-        historyJob?.cancel()
-        historyJob = viewModelScope.launch {
-            _uiState.update {
-                it.copy(
-                    isHistoryLoading = true,
-                    errorMessage = null,
-                )
-            }
-
-            try {
-                recentSearchRepository.clear()
-                    .onSuccess {
-                        if (historyRequestId == requestId) {
-                            _uiState.update { it.copy(recentQueries = emptyList()) }
-                        }
-                    }
-                    .onFailure { exception ->
-                        if (historyRequestId == requestId) {
-                            _uiState.update { it.copy(errorMessage = exception.message) }
-                        }
-                    }
-            } catch (exception: CancellationException) {
-                throw exception
-            } finally {
-                if (historyRequestId == requestId) {
-                    _uiState.update { it.copy(isHistoryLoading = false) }
-                }
-            }
-        }
+        cancelHistoryLoad()
+        runHistoryAction(
+            action = recentSearchRepository::clear,
+            onSuccess = { state, _ -> state.copy(recentQueries = emptyList()) },
+        ).trackHistoryMutation()
     }
 
     fun resetSearchResults() {
@@ -195,15 +140,83 @@ class SearchViewModel @Inject constructor(
     }
 
     fun reset() {
-        historyRequestId++
-        historyJob?.cancel()
-        historyJob = null
+        historyGeneration++
+        cancelHistoryLoad()
+        historyMutationJobs.toList().forEach { it.cancel() }
+        historyMutationJobs.clear()
+        activeHistoryActionCount = 0
         searchQuery.value = ""
         _uiState.value = SearchBarUiState()
     }
 
-    private companion object {
-        const val MIN_SEARCH_LENGTH = 2
-        const val MAX_SEARCH_LENGTH = 20
+    /**
+     * 진행 중인 최근 검색 기록 조회를 취소합니다.
+     *
+     * 삭제 작업은 이 Job을 공유하지 않으므로 연속 삭제 요청이 서로 취소되지 않습니다.
+     */
+    private fun cancelHistoryLoad() {
+        historyLoadRequestId++
+        historyLoadJob?.cancel()
+        historyLoadJob = null
+    }
+
+    /**
+     * 검색 기록 작업의 공통 로딩, 오류 및 성공 상태 반영을 수행합니다.
+     *
+     * @param T 검색 기록 작업이 성공했을 때 반환하는 값의 타입입니다.
+     * @param action 검색 기록 저장소에 요청할 비동기 작업입니다.
+     * @param onSuccess 성공 결과를 현재 UI 상태에 반영하는 함수입니다.
+     * @param canApplyResult 현재 작업 결과를 UI 상태에 반영할 수 있는지 확인하는 함수입니다.
+     * @return 실행 중인 검색 기록 작업의 [Job]입니다.
+     */
+    private fun <T> runHistoryAction(
+        action: suspend () -> Result<T>,
+        onSuccess: (SearchBarUiState, T) -> SearchBarUiState,
+        canApplyResult: () -> Boolean = { true },
+    ): Job {
+        val generation = historyGeneration
+
+        return viewModelScope.launch {
+            if (generation != historyGeneration) return@launch
+
+            activeHistoryActionCount++
+            _uiState.update {
+                it.copy(
+                    isHistoryLoading = true,
+                    errorMessage = null,
+                )
+            }
+
+            try {
+                action()
+                    .onSuccess { result ->
+                        if (generation == historyGeneration && canApplyResult()) {
+                            _uiState.update { state -> onSuccess(state, result) }
+                        }
+                    }
+                    .onFailure { exception ->
+                        if (generation == historyGeneration && canApplyResult()) {
+                            _uiState.update { it.copy(errorMessage = exception.message) }
+                        }
+                    }
+            } catch (exception: CancellationException) {
+                throw exception
+            } finally {
+                if (generation == historyGeneration) {
+                    activeHistoryActionCount = (activeHistoryActionCount - 1).coerceAtLeast(0)
+                    _uiState.update {
+                        it.copy(isHistoryLoading = activeHistoryActionCount > 0)
+                    }
+                }
+            }
+        }
+    }
+
+    /**
+     * 검색 기록 변경 Job을 추적해 [reset] 호출 시 함께 취소합니다.
+     */
+    private fun Job.trackHistoryMutation() {
+        historyMutationJobs += this
+        invokeOnCompletion { historyMutationJobs -= this }
     }
 }

--- a/app/src/test/java/com/linku/search/SearchViewModelTest.kt
+++ b/app/src/test/java/com/linku/search/SearchViewModelTest.kt
@@ -15,6 +15,7 @@ import com.linku.design.top.search.RecentSearchItem
 import com.linku.design.top.search.SearchBarUiState
 import com.linku.design.top.search.SearchResultItem
 import java.io.File
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -215,6 +216,51 @@ class SearchViewModelTest {
         }
 
     @Test
+    fun `latest recent query load ignores stale result after previous load cancellation`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val firstStarted = CompletableDeferred<Unit>()
+            var firstCancelled = false
+            var requestCount = 0
+
+            recentSearchRepository.getHandler = {
+                requestCount++
+                if (requestCount == 1) {
+                    firstStarted.complete(Unit)
+                    try {
+                        awaitCancellation()
+                    } catch (_: CancellationException) {
+                        firstCancelled = true
+                        Result.success(
+                            listOf(
+                                RecentQuery(searchHistoryId = 10L, keyword = "Compose"),
+                            )
+                        )
+                    }
+                } else {
+                    Result.success(
+                        listOf(
+                            RecentQuery(searchHistoryId = 20L, keyword = "Kotlin"),
+                        )
+                    )
+                }
+            }
+
+            viewModel.loadRecentQueries()
+            runCurrent()
+            assertTrue(firstStarted.isCompleted)
+
+            viewModel.loadRecentQueries()
+            advanceUntilIdle()
+
+            assertTrue(firstCancelled)
+            assertEquals(
+                listOf(RecentSearchItem(searchHistoryId = 20L, keyword = "Kotlin")),
+                viewModel.uiState.value.recentQueries,
+            )
+            assertFalse(viewModel.uiState.value.isHistoryLoading)
+        }
+
+    @Test
     fun `removeRecentQuery removes matching id from common ui state`() =
         runTest(mainDispatcherRule.testDispatcher) {
             recentSearchRepository.getResult = Result.success(
@@ -234,6 +280,88 @@ class SearchViewModelTest {
                 listOf(RecentSearchItem(searchHistoryId = 20L, keyword = "Kotlin")),
                 viewModel.uiState.value.recentQueries,
             )
+            assertFalse(viewModel.uiState.value.isHistoryLoading)
+        }
+
+    @Test
+    fun `consecutive remove requests complete independently and keep loading until all finish`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            val firstStarted = CompletableDeferred<Unit>()
+            val secondStarted = CompletableDeferred<Unit>()
+            val firstCompletion = CompletableDeferred<Unit>()
+            val secondCompletion = CompletableDeferred<Unit>()
+
+            recentSearchRepository.getResult = Result.success(
+                listOf(
+                    RecentQuery(searchHistoryId = 10L, keyword = "Compose"),
+                    RecentQuery(searchHistoryId = 20L, keyword = "Kotlin"),
+                )
+            )
+            recentSearchRepository.removeHandler = { searchHistoryId ->
+                when (searchHistoryId) {
+                    10L -> {
+                        firstStarted.complete(Unit)
+                        firstCompletion.await()
+                        Result.success(Unit)
+                    }
+
+                    20L -> {
+                        secondStarted.complete(Unit)
+                        secondCompletion.await()
+                        Result.success(Unit)
+                    }
+
+                    else -> Result.failure(
+                        IllegalArgumentException("예상하지 못한 검색 기록 ID입니다.")
+                    )
+                }
+            }
+
+            viewModel.loadRecentQueries()
+            advanceUntilIdle()
+
+            viewModel.removeRecentQuery(searchHistoryId = 10L)
+            runCurrent()
+            viewModel.removeRecentQuery(searchHistoryId = 20L)
+            runCurrent()
+
+            assertTrue(firstStarted.isCompleted)
+            assertTrue(secondStarted.isCompleted)
+            assertTrue(viewModel.uiState.value.isHistoryLoading)
+
+            firstCompletion.complete(Unit)
+            runCurrent()
+
+            assertEquals(
+                listOf(20L),
+                viewModel.uiState.value.recentQueries.map { it.searchHistoryId },
+            )
+            assertTrue(viewModel.uiState.value.isHistoryLoading)
+
+            secondCompletion.complete(Unit)
+            advanceUntilIdle()
+
+            assertEquals(listOf(10L, 20L), recentSearchRepository.removedIds)
+            assertTrue(viewModel.uiState.value.recentQueries.isEmpty())
+            assertFalse(viewModel.uiState.value.isHistoryLoading)
+        }
+
+    @Test
+    fun `clearRecentQueries clears common ui state`() =
+        runTest(mainDispatcherRule.testDispatcher) {
+            recentSearchRepository.getResult = Result.success(
+                listOf(
+                    RecentQuery(searchHistoryId = 10L, keyword = "Compose"),
+                    RecentQuery(searchHistoryId = 20L, keyword = "Kotlin"),
+                )
+            )
+            viewModel.loadRecentQueries()
+            advanceUntilIdle()
+
+            viewModel.clearRecentQueries()
+            advanceUntilIdle()
+
+            assertTrue(viewModel.uiState.value.recentQueries.isEmpty())
             assertFalse(viewModel.uiState.value.isHistoryLoading)
         }
 
@@ -331,13 +459,15 @@ private class FakeRecentSearchRepository : RecentSearchRepository {
     var getResult: Result<List<RecentQuery>> = Result.success(emptyList())
     var removeResult: Result<Unit> = Result.success(Unit)
     var clearResult: Result<Unit> = Result.success(Unit)
+    var getHandler: suspend () -> Result<List<RecentQuery>> = { getResult }
+    var removeHandler: suspend (Long) -> Result<Unit> = { removeResult }
     val removedIds = mutableListOf<Long>()
 
-    override suspend fun getRecentQueries(): Result<List<RecentQuery>> = getResult
+    override suspend fun getRecentQueries(): Result<List<RecentQuery>> = getHandler()
 
     override suspend fun remove(searchHistoryId: Long): Result<Unit> {
         removedIds += searchHistoryId
-        return removeResult
+        return removeHandler(searchHistoryId)
     }
 
     override suspend fun clear(): Result<Unit> = clearResult

--- a/design/src/main/java/com/linku/design/top/search/SearchBarTopSheet.kt
+++ b/design/src/main/java/com/linku/design/top/search/SearchBarTopSheet.kt
@@ -216,7 +216,7 @@ fun SearchBarTopSheet(
             if(isEditMode){
                 Icon(
                     modifier = Modifier
-                        .noRippleClickable{
+                        .noRippleClickable(enabled = !uiState.isHistoryLoading) {
                             onQueryDelete(item.searchHistoryId)
                         },
                     painter = painterResource(id = R.drawable.ic_recent_search_x),
@@ -552,7 +552,10 @@ fun SearchBarTopSheet(
 
                                     // 모두 지우기 버튼
                                     Text(
-                                        modifier = Modifier.noRippleClickable (onClick = onQueryClear),
+                                        modifier = Modifier.noRippleClickable(
+                                            enabled = !uiState.isHistoryLoading,
+                                            onClick = onQueryClear,
+                                        ),
                                         text = "모두 지우기",
                                         fontSize = 14.sp,
                                         lineHeight = 20.sp,


### PR DESCRIPTION
## 📝 설명

- PR #205 병합 후 반영되지 못한 검색 기록 리뷰 수정 사항을 적용했습니다.
- 검색 기록 조회 Job과 변경 Job을 분리해 연속 삭제 요청이 서로 취소되지 않도록 수정했습니다.
- 검색 기록 작업의 로딩·오류·결과 처리를 `runHistoryAction`으로 통합했습니다.
- 화면 초기화 이전 작업의 결과 반영을 차단하고 진행 중인 변경 작업을 취소하도록 보완했습니다.
- 로딩 중 단건 삭제 및 모두 지우기 입력을 비활성화했습니다.
- 오래된 조회 결과와 동시 삭제 요청에 대한 회귀 테스트를 추가했습니다.

### 검증

- [x] `.\gradlew.bat --no-daemon --console=plain :app:testDebugUnitTest --tests "com.linku.search.SearchViewModelTest"` — 10 tests, failures 0, errors 0
- [x] `.\gradlew.bat --no-daemon --console=plain :app:compileDebugKotlin`
- [x] `git diff --check origin/develop...HEAD`

## ✔️ PR 유형

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호

- 관련 PR: #205
