### PR TITLE
[Fix]: 포그라운드에서 같은 유형의 알림이 여러 개 쌓였을 때 클릭 시 해당 알림의 화면으로 이동하지 않는 버그 수정

### DIFF
--- a/app/src/main/java/com/linku/LinkUFireBaseMessageService.kt
+++ b/app/src/main/java/com/linku/LinkUFireBaseMessageService.kt
@@ -83,6 +83,11 @@ class LinkUFireBaseMessageService : FirebaseMessagingService() {
                     )
                 }
 
+                // 알림마다 고유 ID를 생성해 PendingIntent requestCode로 사용.
+                // requestCode가 동일하면 FLAG_UPDATE_CURRENT가 기존 PendingIntent의 extras를
+                // 덮어써서, 먼저 쌓인 알림이 마지막 알림의 목적지로 이동하는 버그가 발생함.
+                val notificationId = System.currentTimeMillis().toInt()
+
                 // 포그라운드에서 알림을 탭했을 때 앱의 진입 액티비티를 실행하며 알림 데이터를 전달
                 val launchIntent = packageManager.getLaunchIntentForPackage(packageName)
                     ?.apply {
@@ -93,7 +98,7 @@ class LinkUFireBaseMessageService : FirebaseMessagingService() {
 
                 val pendingIntent = PendingIntent.getActivity(
                     this@LinkUFireBaseMessageService,
-                    0,
+                    notificationId,
                     launchIntent,
                     PendingIntent.FLAG_IMMUTABLE or PendingIntent.FLAG_UPDATE_CURRENT
                 ) ?: return@launch
@@ -116,7 +121,7 @@ class LinkUFireBaseMessageService : FirebaseMessagingService() {
 
                 // 알림 출력
                 getSystemService(NotificationManager::class.java)
-                    .notify(System.currentTimeMillis().toInt(), notification)
+                    .notify(notificationId, notification)
 
             } catch (e: IllegalArgumentException) {
                 Log.e("FCM", "FCM 메시지 처리 실패: ${e.message}")

--- a/app/src/main/java/com/linku/LinkUFireBaseMessageService.kt
+++ b/app/src/main/java/com/linku/LinkUFireBaseMessageService.kt
@@ -78,6 +78,7 @@ class LinkUFireBaseMessageService : FirebaseMessagingService() {
                 if (BuildConfig.DEBUG) {
                     Log.d("FCM", """
                     FCM 수신
+                    alarmId: $alarmId
                     title: $title
                     body: $body
                     targetId: $targetId
@@ -85,10 +86,9 @@ class LinkUFireBaseMessageService : FirebaseMessagingService() {
                     )
                 }
 
-                // 알림마다 고유 ID를 생성해 PendingIntent requestCode로 사용.
                 // requestCode가 동일하면 FLAG_UPDATE_CURRENT가 기존 PendingIntent의 extras를
                 // 덮어써서, 먼저 쌓인 알림이 마지막 알림의 목적지로 이동하는 버그가 발생함.
-                val notificationId = UUID.randomUUID().hashCode()
+                val notificationId = alarmId.toInt()
 
                 // 포그라운드에서 알림을 탭했을 때 앱의 진입 액티비티를 실행하며 알림 데이터를 전달
                 val launchIntent = packageManager.getLaunchIntentForPackage(packageName)

--- a/app/src/main/java/com/linku/LinkUFireBaseMessageService.kt
+++ b/app/src/main/java/com/linku/LinkUFireBaseMessageService.kt
@@ -13,6 +13,8 @@ import com.linku.data.preference.NotificationPreference
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.util.UUID
+import java.util.concurrent.atomic.AtomicInteger
 import javax.inject.Inject
 
 
@@ -86,7 +88,7 @@ class LinkUFireBaseMessageService : FirebaseMessagingService() {
                 // 알림마다 고유 ID를 생성해 PendingIntent requestCode로 사용.
                 // requestCode가 동일하면 FLAG_UPDATE_CURRENT가 기존 PendingIntent의 extras를
                 // 덮어써서, 먼저 쌓인 알림이 마지막 알림의 목적지로 이동하는 버그가 발생함.
-                val notificationId = System.currentTimeMillis().toInt()
+                val notificationId = UUID.randomUUID().hashCode()
 
                 // 포그라운드에서 알림을 탭했을 때 앱의 진입 액티비티를 실행하며 알림 데이터를 전달
                 val launchIntent = packageManager.getLaunchIntentForPackage(packageName)


### PR DESCRIPTION
## 📝 설명
- 알림마다 고유 ID를 생성해 PendingIntent requestCode로 사용

## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> #252 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 알림마다 고유 식별자를 사용하도록 개선했습니다.
  * 여러 알림이 서로 덮어쓰이지 않고 개별적으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->