### PR TITLE
Refactor: fcm 토큰 등록 플로우 리팩토링 및 fcm 토큰 삭제 api  연동

### DIFF
--- a/app/src/main/java/com/linku/LinkUFireBaseMessageService.kt
+++ b/app/src/main/java/com/linku/LinkUFireBaseMessageService.kt
@@ -39,7 +39,6 @@ class LinkUFireBaseMessageService : FirebaseMessagingService() {
         }
 
         externalScope.launch {
-            notificationPreference.setFcmToken(token)
             alarmRepository.registerFCMToken(token)
         }
     }

--- a/app/src/main/java/com/linku/LinkUFireBaseMessageService.kt
+++ b/app/src/main/java/com/linku/LinkUFireBaseMessageService.kt
@@ -9,7 +9,7 @@ import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import com.linku.core.di.ApplicationScope
 import com.linku.core.repository.AlarmRepository
-import com.linku.data.preference.NotificationPreference
+import com.linku.core.preference.NotificationPreference
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch

--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -282,7 +282,10 @@ fun MainApp(
         // 다이알로그를 보여줘야 하면 출력.
         if (showPushAlarmDialog) {
             AlarmAllowDialog(
-                onDismissRequest = { showPushAlarmDialog = false },
+                onDismissRequest = {
+                    showPushAlarmDialog = false
+                    viewModel.denyPushAlarm()
+                },
                 onConfirmation = {
                     showPushAlarmDialog = false
                     viewModel.allowPushAlarm() // 성공/실패 토스트는 VM이 쏨

--- a/app/src/main/java/com/linku/MainViewModel.kt
+++ b/app/src/main/java/com/linku/MainViewModel.kt
@@ -232,6 +232,15 @@ class MainViewModel @Inject constructor(
         return pending
     }
 
+    // "안하기" 선택 시 서버 알림 설정이 활성화 상태라면 비활성화 API 호출
+    fun denyPushAlarm() {
+        viewModelScope.launch {
+            if (notificationPreference.isMasterNotificationEnabled()) {
+                alarmRepository.updateAlarmSetting(AlarmType.ALL)
+            }
+        }
+    }
+
     fun allowPushAlarm() {
         viewModelScope.launch {
             firstPushAlarmAllowedUseCase()

--- a/app/src/main/java/com/linku/MainViewModel.kt
+++ b/app/src/main/java/com/linku/MainViewModel.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.linku.core.model.alarm.AlarmType
@@ -55,6 +56,17 @@ class MainViewModel @Inject constructor(
     // 로그인/자동 로그인 성공 시 true, 로그아웃 시 false로 갱신
     fun setAuthenticated(value: Boolean) {
         _isAuthenticated.value = value
+        if (value) reRegisterFcmToken()
+    }
+
+    private fun reRegisterFcmToken() {
+        viewModelScope.launch {
+            alarmRepository.getFCMTokenFromFCM()
+                .onSuccess {
+                    token -> alarmRepository.registerFCMToken(token)
+                    Log.d("FCM", "FCM 토큰 재등록 성공")
+                }
+        }
     }
 
     // 로그인 세션 반영함.

--- a/app/src/main/java/com/linku/MainViewModel.kt
+++ b/app/src/main/java/com/linku/MainViewModel.kt
@@ -14,7 +14,7 @@ import com.linku.core.repository.UserRepository
 import com.linku.core.usecase.FirstPushAlarmAllowedUseCase
 import com.linku.core.usecase.ReRegisterFcmTokenUseCase
 import com.linku.data.preference.AuthPreference
-import com.linku.data.preference.NotificationPreference
+import com.linku.core.preference.NotificationPreference
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.awaitClose

--- a/app/src/main/java/com/linku/MainViewModel.kt
+++ b/app/src/main/java/com/linku/MainViewModel.kt
@@ -5,6 +5,7 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
+import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.linku.core.model.alarm.AlarmType
@@ -78,12 +79,14 @@ class MainViewModel @Inject constructor(
 
             // fcm토큰 재등록
             reRegisterFcmTokenUseCase()
+                //로그인 직후 백그라운드에서 조용히 실행되는 작업이므로
+                //UI 개입을 최소화
                 .fold(
                     onSuccess ={
-
+                        Log.d("FCM", "FCM 토큰 재등록 성공")
                     },
                     onFailure = {
-
+                        Log.w("FCM", "FCM 토큰 재등록 실패(다음 로그인 때 재시도)")
                     }
                 )
         }

--- a/app/src/main/java/com/linku/MainViewModel.kt
+++ b/app/src/main/java/com/linku/MainViewModel.kt
@@ -5,7 +5,6 @@ import android.net.ConnectivityManager
 import android.net.Network
 import android.net.NetworkCapabilities
 import android.net.NetworkRequest
-import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.viewModelScope
 import com.linku.core.model.alarm.AlarmType
@@ -13,6 +12,7 @@ import com.linku.core.repository.AlarmRepository
 import com.linku.core.repository.RecentSearchRepository
 import com.linku.core.repository.UserRepository
 import com.linku.core.usecase.FirstPushAlarmAllowedUseCase
+import com.linku.core.usecase.ReRegisterFcmTokenUseCase
 import com.linku.data.preference.AuthPreference
 import com.linku.data.preference.NotificationPreference
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -36,6 +36,7 @@ class MainViewModel @Inject constructor(
     private val authPreference: AuthPreference,
     private val userRepository: UserRepository, // 닉네임 호출용
     private val firstPushAlarmAllowedUseCase: FirstPushAlarmAllowedUseCase,
+    private val reRegisterFcmTokenUseCase: ReRegisterFcmTokenUseCase,
     private val alarmRepository: AlarmRepository,
 ) : AndroidViewModel(application) {
 
@@ -61,11 +62,19 @@ class MainViewModel @Inject constructor(
 
     private fun reRegisterFcmToken() {
         viewModelScope.launch {
-            alarmRepository.getFCMTokenFromFCM()
-                .onSuccess {
-                    token -> alarmRepository.registerFCMToken(token)
-                    Log.d("FCM", "FCM 토큰 재등록 성공")
-                }
+            // 최초알림팝업을 통한 fcm토큰등록이 진행되었다면 스킵
+            if (!notificationPreference.isFcmTokenRegistered()) return@launch
+
+            // fcm토큰 재등록
+            reRegisterFcmTokenUseCase()
+                .fold(
+                    onSuccess ={
+
+                    },
+                    onFailure = {
+
+                    }
+                )
         }
     }
 

--- a/app/src/main/java/com/linku/MainViewModel.kt
+++ b/app/src/main/java/com/linku/MainViewModel.kt
@@ -57,7 +57,16 @@ class MainViewModel @Inject constructor(
     // 로그인/자동 로그인 성공 시 true, 로그아웃 시 false로 갱신
     fun setAuthenticated(value: Boolean) {
         _isAuthenticated.value = value
-        if (value) reRegisterFcmToken()
+        if (value) {
+            reRegisterFcmToken()
+            syncAlarmSetting()
+        }
+    }
+
+    private fun syncAlarmSetting() {
+        viewModelScope.launch {
+            alarmRepository.getAlarmSetting()
+        }
     }
 
     private fun reRegisterFcmToken() {

--- a/app/src/main/java/com/linku/MainViewModel.kt
+++ b/app/src/main/java/com/linku/MainViewModel.kt
@@ -74,7 +74,9 @@ class MainViewModel @Inject constructor(
 
     private fun reRegisterFcmToken() {
         viewModelScope.launch {
-            // 최초알림팝업을 통한 fcm토큰등록이 진행되었다면 스킵
+            // FCM 토큰을 서버에 등록한 적이 없거나
+            // 로그아웃을 통해 delete 처리가 되었다면 스킵
+            // 위의 경우에는 푸시알림 팝업을 통해서 토큰을 POST한다.
             if (!notificationPreference.isFcmTokenRegistered()) return@launch
 
             // fcm토큰 재등록

--- a/app/src/main/java/com/linku/Splash.kt
+++ b/app/src/main/java/com/linku/Splash.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.unit.dp
 import com.linku.core.model.SystemBarMode
 import com.linku.core.system.SystemBarController
-import com.linku.data.preference.NotificationPreference
+import com.linku.data.preference.NotificationPreferenceImpl
 import com.linku.design.util.PixelScaler
 import kotlinx.coroutines.delay
 
@@ -71,7 +71,7 @@ fun Splash(onResult: () -> Unit) {
     // 스플래시에서만 일회성으로 사용하는 값이라 Hilt & ViewModel 없이 직접 생성.
     val context = LocalContext.current
     val notificationPreference = remember {
-        NotificationPreference(context)
+        NotificationPreferenceImpl(context)
     }
 
     LaunchedEffect(Unit) {

--- a/core/src/main/java/com/linku/core/di/UseCaseModule.kt
+++ b/core/src/main/java/com/linku/core/di/UseCaseModule.kt
@@ -2,6 +2,7 @@ package com.linku.core.di
 
 import com.linku.core.repository.AlarmRepository
 import com.linku.core.usecase.FirstPushAlarmAllowedUseCase
+import com.linku.core.usecase.ReRegisterFcmTokenUseCase
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -34,6 +35,14 @@ object UseCaseModule {
         alarmRepository: AlarmRepository
     ): FirstPushAlarmAllowedUseCase {
         return FirstPushAlarmAllowedUseCase(alarmRepository)
+    }
+
+    @Provides
+    @Singleton
+    fun provideReRegisterFcmTokenUseCase(
+        alarmRepository: AlarmRepository
+    ): ReRegisterFcmTokenUseCase {
+        return ReRegisterFcmTokenUseCase(alarmRepository)
     }
 
 }

--- a/core/src/main/java/com/linku/core/preference/NotificationPreference.kt
+++ b/core/src/main/java/com/linku/core/preference/NotificationPreference.kt
@@ -1,0 +1,38 @@
+package com.linku.core.preference
+
+import kotlinx.coroutines.flow.Flow
+
+interface NotificationPreference {
+
+    // ===== Notification =====
+
+    val masterNotificationEnabled: Flow<Boolean>
+
+    suspend fun isMasterNotificationEnabled(): Boolean
+
+    suspend fun setMasterNotificationEnabled(enabled: Boolean)
+
+    // ===== FCM Token =====
+
+    suspend fun getFcmToken(): String?
+
+    suspend fun setFcmToken(token: String)
+
+    // ===== FCM Token Server Registration =====
+
+    suspend fun isFcmTokenRegistered(): Boolean
+
+    suspend fun setFcmTokenRegistered(registered: Boolean)
+
+    suspend fun clearFcmToken()
+
+    // ===== Dialog State =====
+
+    suspend fun isSystemPermissionRequested(): Boolean
+
+    suspend fun setSystemPermissionRequested(requested: Boolean)
+
+    suspend fun isPushPermissionRequested(): Boolean
+
+    suspend fun setPushPermissionRequested(requested: Boolean)
+}

--- a/core/src/main/java/com/linku/core/preference/NotificationPreference.kt
+++ b/core/src/main/java/com/linku/core/preference/NotificationPreference.kt
@@ -12,19 +12,11 @@ interface NotificationPreference {
 
     suspend fun setMasterNotificationEnabled(enabled: Boolean)
 
-    // ===== FCM Token =====
-
-    suspend fun getFcmToken(): String?
-
-    suspend fun setFcmToken(token: String)
-
     // ===== FCM Token Server Registration =====
 
     suspend fun isFcmTokenRegistered(): Boolean
 
     suspend fun setFcmTokenRegistered(registered: Boolean)
-
-    suspend fun clearFcmToken()
 
     // ===== Dialog State =====
 

--- a/core/src/main/java/com/linku/core/repository/AlarmRepository.kt
+++ b/core/src/main/java/com/linku/core/repository/AlarmRepository.kt
@@ -28,4 +28,8 @@ interface AlarmRepository {
 
     suspend fun getUnreadAlarmExists(): Result<Boolean>
 
+    suspend fun deleteFcmToken(
+        token: String
+    ): Result<Unit>
+
 }

--- a/core/src/main/java/com/linku/core/repository/UserRepository.kt
+++ b/core/src/main/java/com/linku/core/repository/UserRepository.kt
@@ -24,8 +24,8 @@ interface UserRepository {
         interests: List<String>
     ): Result<Unit>
 
-    // 로그아웃. 성공(서버 호출 + 로컬 세션 정리)했을 때만 true.
-    suspend fun logout(): Boolean
+    // 로그아웃. 성공(서버 호출 + 로컬 세션 정리)했을 때만 Success.
+    suspend fun logout(): Result<Unit>
 
     // 닉네임만 호출
     suspend fun getNickname(): String?

--- a/core/src/main/java/com/linku/core/usecase/FirstPushAlarmAllowedUseCase.kt
+++ b/core/src/main/java/com/linku/core/usecase/FirstPushAlarmAllowedUseCase.kt
@@ -29,8 +29,16 @@ class FirstPushAlarmAllowedUseCase @Inject constructor(
         alarmRepository.registerFCMToken(currentFcmToken)
             .getOrThrow()
 
-        alarmRepository.updateAlarmSetting(AlarmType.ALL)
+        // 로그인한 유저의 알림 설정이 이미 활성화되어있는지 여부 확인
+        val isAlreadyEnabled = alarmRepository.getAlarmSetting()
             .getOrThrow()
+            .isAllEnabled
+
+        // 활성화되어있지 않을 때만 업데이트 api 호출
+        if (!isAlreadyEnabled) {
+            alarmRepository.updateAlarmSetting(AlarmType.ALL)
+                .getOrThrow()
+        }
 
         Unit
 

--- a/core/src/main/java/com/linku/core/usecase/LogoutUseCase.kt
+++ b/core/src/main/java/com/linku/core/usecase/LogoutUseCase.kt
@@ -1,0 +1,16 @@
+package com.linku.core.usecase
+
+import com.linku.core.preference.NotificationPreference
+import com.linku.core.repository.AlarmRepository
+import com.linku.core.repository.UserRepository
+import javax.inject.Inject
+
+class LogoutUseCase @Inject constructor(
+    private val userRepository: UserRepository,
+    private val alarmRepository: AlarmRepository,
+    private val notificationPreference: NotificationPreference
+) {
+    suspend operator fun invoke(): Result<Unit> = runCatching {
+
+    }
+}

--- a/core/src/main/java/com/linku/core/usecase/LogoutUseCase.kt
+++ b/core/src/main/java/com/linku/core/usecase/LogoutUseCase.kt
@@ -1,6 +1,7 @@
 package com.linku.core.usecase
 
 import android.util.Log
+import com.linku.core.BuildConfig
 import com.linku.core.repository.AlarmRepository
 import com.linku.core.repository.UserRepository
 import kotlinx.coroutines.CancellationException
@@ -25,7 +26,9 @@ class LogoutUseCase @Inject constructor(
         val token = alarmRepository.getFCMTokenFromFCM()
             .getOrNull()
 
-        Log.d("FCM", "로그아웃 시 FCM 토큰: $token")
+        if (BuildConfig.DEBUG) {
+            Log.d("FCM", "로그아웃 시 FCM 토큰: $token")
+        }
 
         if (token != null) {
             alarmRepository.deleteFcmToken(token)

--- a/core/src/main/java/com/linku/core/usecase/LogoutUseCase.kt
+++ b/core/src/main/java/com/linku/core/usecase/LogoutUseCase.kt
@@ -1,16 +1,30 @@
 package com.linku.core.usecase
 
-import com.linku.core.preference.NotificationPreference
 import com.linku.core.repository.AlarmRepository
 import com.linku.core.repository.UserRepository
+import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 
 class LogoutUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val alarmRepository: AlarmRepository,
-    private val notificationPreference: NotificationPreference
 ) {
     suspend operator fun invoke(): Result<Unit> = runCatching {
+        // FCM 토큰 조회 후 서버에서 삭제 (실패해도 로그아웃은 계속 진행)
+        val token = alarmRepository.getFCMTokenFromFCM()
+            .getOrNull()
 
+        if (token != null) {
+            alarmRepository.deleteFcmToken(token)
+        }
+
+        // 2. 로그아웃 API 호출 + 로컬 세션 정리
+        userRepository.logout()
+            .getOrThrow()
+
+    }.onFailure {
+        // 사용자가 화면을 나가는 등의 이유로 발생하는 CancellationException는
+        // 정상 흐름이므로 Result로 감싸지 않고 그대로 전파
+        if (it is CancellationException) throw it
     }
 }

--- a/core/src/main/java/com/linku/core/usecase/LogoutUseCase.kt
+++ b/core/src/main/java/com/linku/core/usecase/LogoutUseCase.kt
@@ -1,10 +1,21 @@
 package com.linku.core.usecase
 
+import android.util.Log
 import com.linku.core.repository.AlarmRepository
 import com.linku.core.repository.UserRepository
 import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 
+/**
+ * 로그아웃 처리를 담당하는 UseCase입니다.
+ *
+ * 이 UseCase는 다음 과정을 수행합니다:
+ * 1. 현재 기기의 FCM 토큰을 조회하여 서버에서 삭제합니다. (실패하더라도 로그아웃 프로세스는 계속 진행됩니다.)
+ * 2. 서버에 로그아웃 요청을 보내고, 로컬에 저장된 사용자 세션 및 인증 정보를 초기화합니다.
+ *
+ * @property userRepository 사용자 정보 및 세션 관리를 위한 레포지토리
+ * @property alarmRepository 알림 및 FCM 토큰 관리를 위한 레포지토리
+ */
 class LogoutUseCase @Inject constructor(
     private val userRepository: UserRepository,
     private val alarmRepository: AlarmRepository,
@@ -14,11 +25,13 @@ class LogoutUseCase @Inject constructor(
         val token = alarmRepository.getFCMTokenFromFCM()
             .getOrNull()
 
+        Log.d("FCM", "로그아웃 시 FCM 토큰: $token")
+
         if (token != null) {
             alarmRepository.deleteFcmToken(token)
         }
 
-        // 2. 로그아웃 API 호출 + 로컬 세션 정리
+        // 로그아웃 API 호출 + 로컬 세션 정리
         userRepository.logout()
             .getOrThrow()
 

--- a/core/src/main/java/com/linku/core/usecase/ReRegisterFcmTokenUseCase.kt
+++ b/core/src/main/java/com/linku/core/usecase/ReRegisterFcmTokenUseCase.kt
@@ -1,0 +1,24 @@
+package com.linku.core.usecase
+
+import android.util.Log
+import com.linku.core.repository.AlarmRepository
+import javax.inject.Inject
+
+/**
+ * Firebase Cloud Messaging(FCM) 토큰을 재등록하기 위한 Use Case입니다.
+ *
+ * Firebase 서비스에서 현재 FCM 토큰을 가져온 후, [AlarmRepository]를 통해
+ * 애플리케이션의 백엔드 서버에 해당 토큰을 등록합니다.
+ * 사용자가 자동로그인이든 수동로그인이든 로그인했을 때 호출됩니다.
+ *
+ * @property alarmRepository FCM 토큰 작업 및 알림 설정을 관리하는 Repository입니다.
+ */
+class ReRegisterFcmTokenUseCase @Inject constructor(
+    private val alarmRepository: AlarmRepository,
+) {
+    suspend operator fun invoke(): Result<Unit> = runCatching {
+        val token = alarmRepository.getFCMTokenFromFCM().getOrThrow()
+        alarmRepository.registerFCMToken(token).getOrThrow()
+        Log.d("FCM", "FCM 토큰 재등록 성공")
+    }
+}

--- a/core/src/main/java/com/linku/core/usecase/ReRegisterFcmTokenUseCase.kt
+++ b/core/src/main/java/com/linku/core/usecase/ReRegisterFcmTokenUseCase.kt
@@ -2,6 +2,7 @@ package com.linku.core.usecase
 
 import android.util.Log
 import com.linku.core.repository.AlarmRepository
+import kotlinx.coroutines.CancellationException
 import javax.inject.Inject
 
 /**
@@ -20,5 +21,11 @@ class ReRegisterFcmTokenUseCase @Inject constructor(
         val token = alarmRepository.getFCMTokenFromFCM().getOrThrow()
         alarmRepository.registerFCMToken(token).getOrThrow()
         Log.d("FCM", "FCM 토큰 재등록 성공")
+
+        Unit
+    }.onFailure {
+        // 사용자가 화면을 나가는 등의 이유로 발생하는 CancellationException는
+        // 정상 흐름이므로 Result로 감싸지 않고 그대로 전파
+        if (it is CancellationException) throw it
     }
 }

--- a/data/src/main/java/com/linku/data/api/alarm/AlarmApi.kt
+++ b/data/src/main/java/com/linku/data/api/alarm/AlarmApi.kt
@@ -9,6 +9,7 @@ import com.linku.data.api.dto.alarm.AlarmsDTO
 import com.linku.data.api.dto.alarm.FcmTokenRequest
 import com.linku.data.api.dto.alarm.UnreadAlarmExistDTO
 import retrofit2.http.Body
+import retrofit2.http.DELETE
 import retrofit2.http.GET
 import retrofit2.http.PATCH
 import retrofit2.http.POST
@@ -50,6 +51,11 @@ interface AlarmApi {
 
     @GET("alarm/unread")
     suspend fun getUnreadAlarmExists(): BaseResponse<UnreadAlarmExistDTO>
+
+    @DELETE("alarm/fcmtoken")
+    suspend fun deleteFcmToken(
+        @Body body: FcmTokenRequest
+    ): BaseResponse<Any?>
 
 
 }

--- a/data/src/main/java/com/linku/data/api/alarm/AlarmApi.kt
+++ b/data/src/main/java/com/linku/data/api/alarm/AlarmApi.kt
@@ -11,6 +11,7 @@ import com.linku.data.api.dto.alarm.UnreadAlarmExistDTO
 import retrofit2.http.Body
 import retrofit2.http.DELETE
 import retrofit2.http.GET
+import retrofit2.http.HTTP
 import retrofit2.http.PATCH
 import retrofit2.http.POST
 import retrofit2.http.Path
@@ -52,7 +53,7 @@ interface AlarmApi {
     @GET("alarm/unread")
     suspend fun getUnreadAlarmExists(): BaseResponse<UnreadAlarmExistDTO>
 
-    @DELETE("alarm/fcmtoken")
+    @HTTP(method = "DELETE", path = "alarm/fcmtoken", hasBody = true)
     suspend fun deleteFcmToken(
         @Body body: FcmTokenRequest
     ): BaseResponse<Any?>

--- a/data/src/main/java/com/linku/data/di/preference/NotificationPreferenceModule.kt
+++ b/data/src/main/java/com/linku/data/di/preference/NotificationPreferenceModule.kt
@@ -1,7 +1,8 @@
 package com.linku.data.di.preference
 
 import android.content.Context
-import com.linku.data.preference.NotificationPreference
+import com.linku.core.preference.NotificationPreference
+import com.linku.data.preference.NotificationPreferenceImpl
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -17,6 +18,6 @@ object NotificationPreferenceModule {
     fun provideNotificationPreference(
         @ApplicationContext context: Context
     ): NotificationPreference {
-        return NotificationPreference(context)
+        return NotificationPreferenceImpl(context)
     }
 }

--- a/data/src/main/java/com/linku/data/implementation/repository/AlarmRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/AlarmRepositoryImpl.kt
@@ -122,6 +122,7 @@ class AlarmRepositoryImpl @Inject constructor(
         }.onSuccess {
             notificationPreference.setFcmTokenRegistered(false)
             notificationPreference.setPushPermissionRequested(false)
+            notificationPreference.setMasterNotificationEnabled(false)
             Log.d("FCM", "fcm 토큰 삭제 완료")
         }.onFailure { e ->
             Log.e("FCM", "fcm 토큰 삭제 실패: ${e::class.simpleName} - ${e.message}")

--- a/data/src/main/java/com/linku/data/implementation/repository/AlarmRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/AlarmRepositoryImpl.kt
@@ -10,7 +10,7 @@ import com.linku.core.model.alarm.AlarmSetting
 import com.linku.core.model.alarm.AlarmSummary
 import com.linku.core.model.alarm.AlarmType
 import com.linku.core.repository.AlarmRepository
-import com.linku.data.preference.NotificationPreference
+import com.linku.core.preference.NotificationPreference
 import com.linku.data.api.alarm.AlarmApi
 import com.linku.data.api.dto.alarm.AlarmSettingRequest
 import com.linku.data.api.dto.alarm.FcmTokenRequest

--- a/data/src/main/java/com/linku/data/implementation/repository/AlarmRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/AlarmRepositoryImpl.kt
@@ -112,6 +112,16 @@ class AlarmRepositoryImpl @Inject constructor(
         }.map { it.hasUnread }
     }
 
+    override suspend fun deleteFcmToken(
+        token: String
+    ): Result<Unit> {
+        return safeApiCallUnit {
+            alarmApi.deleteFcmToken(
+                FcmTokenRequest(token)
+            )
+        }
+    }
+
 }
 
 

--- a/data/src/main/java/com/linku/data/implementation/repository/AlarmRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/AlarmRepositoryImpl.kt
@@ -119,6 +119,10 @@ class AlarmRepositoryImpl @Inject constructor(
             alarmApi.deleteFcmToken(
                 FcmTokenRequest(token)
             )
+        }.onSuccess{
+            notificationPreference.setFcmTokenRegistered(false)
+            notificationPreference.setPushPermissionRequested(false)
+            Log.d("FCM", "fcm 토큰 삭제 완료")
         }
     }
 

--- a/data/src/main/java/com/linku/data/implementation/repository/AlarmRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/AlarmRepositoryImpl.kt
@@ -119,10 +119,12 @@ class AlarmRepositoryImpl @Inject constructor(
             alarmApi.deleteFcmToken(
                 FcmTokenRequest(token)
             )
-        }.onSuccess{
+        }.onSuccess {
             notificationPreference.setFcmTokenRegistered(false)
             notificationPreference.setPushPermissionRequested(false)
             Log.d("FCM", "fcm 토큰 삭제 완료")
+        }.onFailure { e ->
+            Log.e("FCM", "fcm 토큰 삭제 실패: ${e::class.simpleName} - ${e.message}")
         }
     }
 

--- a/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
+++ b/data/src/main/java/com/linku/data/implementation/repository/UserRepositoryImpl.kt
@@ -116,21 +116,20 @@ class UserRepositoryImpl @Inject constructor(
     }
 
     // logout. deleteUser()와 동일하게 서버 호출이 성공했을 때만 로컬 세션을 지움.
-    override suspend fun logout(): Boolean {
+    override suspend fun logout(): Result<Unit> {
         return try {
-            // getDeviceId() 실패도 try 안에서 잡아야 false로 이어져 onError 처리가 정상 동작함.
             val deviceId = authPreference.getDeviceId()
             Log.d(TAG, "[로그아웃 시도] deviceId=$deviceId")
 
             safeApiCallUnit { serverApi.logout(deviceId) }.getOrThrow()
             authPreference.clear()
             Log.d(TAG, "로그아웃 완료")
-            true
+            Result.success(Unit)
         } catch (e: CancellationException) {
             throw e
         } catch (e: Exception) {
             Log.e(TAG, "[로그아웃 실패] ${e.message}")
-            false
+            Result.failure(e)
         }
     }
 

--- a/data/src/main/java/com/linku/data/preference/NotificationPreference.kt
+++ b/data/src/main/java/com/linku/data/preference/NotificationPreference.kt
@@ -5,15 +5,16 @@ import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
 import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
+import com.linku.core.preference.NotificationPreference
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 
 private val Context.notificationDataStore by preferencesDataStore(name = "notification_prefs")
 
-class NotificationPreference(
+class NotificationPreferenceImpl(
     private val context: Context
-) {
+) : NotificationPreference {
 
     private object Keys {
         val NOTIFICATION_MASTER = booleanPreferencesKey("key_notification_master")
@@ -26,14 +27,14 @@ class NotificationPreference(
     // ===== Notification =====
 
     // 실시간 구독용 Flow (AlarmViewModel 등에서 StateFlow로 변환하여 사용)
-    val masterNotificationEnabled: Flow<Boolean> = context.notificationDataStore.data.map { prefs ->
+    override val masterNotificationEnabled: Flow<Boolean> = context.notificationDataStore.data.map { prefs ->
         prefs[Keys.NOTIFICATION_MASTER] ?: true
     }
 
-    suspend fun isMasterNotificationEnabled(): Boolean =
+    override suspend fun isMasterNotificationEnabled(): Boolean =
         context.notificationDataStore.data.map { it[Keys.NOTIFICATION_MASTER] ?: true }.first()
 
-    suspend fun setMasterNotificationEnabled(enabled: Boolean) {
+    override suspend fun setMasterNotificationEnabled(enabled: Boolean) {
         context.notificationDataStore.edit { prefs ->
             prefs[Keys.NOTIFICATION_MASTER] = enabled
         }
@@ -42,10 +43,10 @@ class NotificationPreference(
     // ===== FCM Token =====
 
     // TODO: FCM 토큰 유효성 검사에 사용 예정
-    suspend fun getFcmToken(): String? =
+    override suspend fun getFcmToken(): String? =
         context.notificationDataStore.data.map { it[Keys.FCM_TOKEN] }.first()
 
-    suspend fun setFcmToken(token: String) {
+    override suspend fun setFcmToken(token: String) {
         context.notificationDataStore.edit { prefs ->
             prefs[Keys.FCM_TOKEN] = token
         }
@@ -53,17 +54,17 @@ class NotificationPreference(
 
     // ===== FCM Token Server Registration =====
 
-    suspend fun isFcmTokenRegistered(): Boolean =
+    override suspend fun isFcmTokenRegistered(): Boolean =
         context.notificationDataStore.data.map { it[Keys.FCM_TOKEN_REGISTERED] ?: false }.first()
 
-    suspend fun setFcmTokenRegistered(registered: Boolean) {
+    override suspend fun setFcmTokenRegistered(registered: Boolean) {
         context.notificationDataStore.edit { prefs ->
             prefs[Keys.FCM_TOKEN_REGISTERED] = registered
         }
     }
 
     //TODO: fcm토큰 삭제 api 연동 작업 시에 사용 예정
-    suspend fun clearFcmToken() {
+    override suspend fun clearFcmToken() {
         context.notificationDataStore.edit { prefs ->
             prefs.remove(Keys.FCM_TOKEN)
         }
@@ -71,19 +72,19 @@ class NotificationPreference(
 
     // ===== Dialog State =====
 
-    suspend fun isSystemPermissionRequested(): Boolean =
+    override suspend fun isSystemPermissionRequested(): Boolean =
         context.notificationDataStore.data.map { it[Keys.SYSTEM_PERMISSION_REQUESTED] ?: false }.first()
 
-    suspend fun setSystemPermissionRequested(requested: Boolean) {
+    override suspend fun setSystemPermissionRequested(requested: Boolean) {
         context.notificationDataStore.edit { prefs ->
             prefs[Keys.SYSTEM_PERMISSION_REQUESTED] = requested
         }
     }
 
-    suspend fun isPushPermissionRequested(): Boolean =
+    override suspend fun isPushPermissionRequested(): Boolean =
         context.notificationDataStore.data.map { it[Keys.PUSH_PERMISSION_REQUESTED] ?: false }.first()
 
-    suspend fun setPushPermissionRequested(requested: Boolean) {
+    override suspend fun setPushPermissionRequested(requested: Boolean) {
         context.notificationDataStore.edit { prefs ->
             prefs[Keys.PUSH_PERMISSION_REQUESTED] = requested
         }

--- a/data/src/main/java/com/linku/data/preference/NotificationPreferenceImpl.kt
+++ b/data/src/main/java/com/linku/data/preference/NotificationPreferenceImpl.kt
@@ -3,7 +3,6 @@ package com.linku.data.preference
 import android.content.Context
 import androidx.datastore.preferences.core.booleanPreferencesKey
 import androidx.datastore.preferences.core.edit
-import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.linku.core.preference.NotificationPreference
 import kotlinx.coroutines.flow.Flow
@@ -18,7 +17,6 @@ class NotificationPreferenceImpl(
 
     private object Keys {
         val NOTIFICATION_MASTER = booleanPreferencesKey("key_notification_master")
-        val FCM_TOKEN = stringPreferencesKey("key_fcm_token")
         val FCM_TOKEN_REGISTERED = booleanPreferencesKey("key_fcm_token_registered")
         val SYSTEM_PERMISSION_REQUESTED = booleanPreferencesKey("key_system_permission_requested")
         val PUSH_PERMISSION_REQUESTED = booleanPreferencesKey("key_push_permission_requested")
@@ -40,18 +38,6 @@ class NotificationPreferenceImpl(
         }
     }
 
-    // ===== FCM Token =====
-
-    // TODO: FCM 토큰 유효성 검사에 사용 예정
-    override suspend fun getFcmToken(): String? =
-        context.notificationDataStore.data.map { it[Keys.FCM_TOKEN] }.first()
-
-    override suspend fun setFcmToken(token: String) {
-        context.notificationDataStore.edit { prefs ->
-            prefs[Keys.FCM_TOKEN] = token
-        }
-    }
-
     // ===== FCM Token Server Registration =====
 
     override suspend fun isFcmTokenRegistered(): Boolean =
@@ -60,13 +46,6 @@ class NotificationPreferenceImpl(
     override suspend fun setFcmTokenRegistered(registered: Boolean) {
         context.notificationDataStore.edit { prefs ->
             prefs[Keys.FCM_TOKEN_REGISTERED] = registered
-        }
-    }
-
-    //TODO: fcm토큰 삭제 api 연동 작업 시에 사용 예정
-    override suspend fun clearFcmToken() {
-        context.notificationDataStore.edit { prefs ->
-            prefs.remove(Keys.FCM_TOKEN)
         }
     }
 

--- a/feature/home/src/main/java/com/linku/home/viewmodel/AlarmViewModel.kt
+++ b/feature/home/src/main/java/com/linku/home/viewmodel/AlarmViewModel.kt
@@ -7,7 +7,7 @@ import androidx.paging.cachedIn
 import com.linku.core.model.alarm.AlarmSummary
 import com.linku.core.model.alarm.AlarmType
 import com.linku.core.repository.AlarmRepository
-import com.linku.data.preference.NotificationPreference
+import com.linku.core.preference.NotificationPreference
 import com.linku.home.model.AlarmIntent
 import com.linku.home.model.AlarmSideEffect
 import dagger.hilt.android.lifecycle.HiltViewModel

--- a/feature/mypage/src/main/java/com/linku/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/linku/mypage/MyPageViewModel.kt
@@ -7,6 +7,7 @@ import com.linku.core.model.UserInfo
 import com.linku.core.model.auth.UserSession
 import com.linku.core.repository.AlarmRepository
 import com.linku.core.repository.UserRepository
+import com.linku.core.usecase.LogoutUseCase
 import com.linku.data.preference.AuthPreference
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -21,7 +22,8 @@ import javax.inject.Inject
 class MyPageViewModel @Inject constructor(
     private val userRepository: UserRepository,
     private val alarmRepository: AlarmRepository,
-    private val authPreference: AuthPreference
+    private val authPreference: AuthPreference,
+    private val logoutUseCase: LogoutUseCase,
 ): ViewModel() {
     val sessionState: StateFlow<UserSession> = authPreference.sessionState
         .stateIn(
@@ -173,11 +175,9 @@ class MyPageViewModel @Inject constructor(
         }
     }
 
-    // 로그아웃 */
-    // TODO: FCM토큰 삭제 API호출
     fun logout(onSuccess: () -> Unit, onError: (String) -> Unit) {
         viewModelScope.launch {
-            userRepository.logout()
+            logoutUseCase()
                 .fold(
                     onSuccess = {
                         _uiState.value = MyPageUiState()

--- a/feature/mypage/src/main/java/com/linku/mypage/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/linku/mypage/MyPageViewModel.kt
@@ -177,13 +177,14 @@ class MyPageViewModel @Inject constructor(
     // TODO: FCM토큰 삭제 API호출
     fun logout(onSuccess: () -> Unit, onError: (String) -> Unit) {
         viewModelScope.launch {
-            val success = userRepository.logout()
-            if (success) {
-                _uiState.value = MyPageUiState()
-                onSuccess()
-            } else {
-                onError("로그아웃에 실패했습니다.")
-            }
+            userRepository.logout()
+                .fold(
+                    onSuccess = {
+                        _uiState.value = MyPageUiState()
+                        onSuccess()
+                    },
+                    onFailure = { onError("로그아웃에 실패했습니다.") }
+                )
         }
     }
 

--- a/feature/mypage/src/main/java/com/linku/mypage/NotificationViewModel.kt
+++ b/feature/mypage/src/main/java/com/linku/mypage/NotificationViewModel.kt
@@ -7,7 +7,7 @@ import com.linku.core.model.alarm.AlarmSetting
 import com.linku.core.repository.AlarmRepository
 import com.linku.core.system.PermissionChecker
 import com.linku.core.usecase.FirstPushAlarmAllowedUseCase
-import com.linku.data.preference.NotificationPreference
+import com.linku.core.preference.NotificationPreference
 import com.linku.mypage.intent.ConfirmFirstPushPermission
 import com.linku.mypage.intent.LinkuNotificationIntent
 import com.linku.mypage.intent.NotificationIntent


### PR DESCRIPTION
## 📝 설명
- 로그인 성공시마다 fcm 토큰 재등록 로직 추가
  - fcm토큰 재등록 유스케이스 추가
- 로그아웃 시 fcm토큰 삭제 및 관련 Datastore 키값 초기화
- 로그아웃 유스케이스로 리팩토링
- 
## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> #254 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 로그인 후 푸시 알림 토큰을 자동으로 재등록합니다.
  * 로그아웃 시 등록된 푸시 알림 토큰을 삭제하고 세션을 정리합니다.
  * 푸시 알림 권한을 거부하면 전체 알림 설정이 비활성화됩니다.
  * 알림 권한 및 토큰 등록 상태를 안정적으로 저장하고 관리합니다.

* **개선 사항**
  * 이미 활성화된 알림 설정에 대한 불필요한 업데이트 요청을 생략합니다.
  * 로그아웃 및 토큰 처리 결과를 성공 또는 실패 상태로 명확하게 처리합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->