### PR TITLE
🐛 fix(navigation): 파일 탭 재선택 시 폴더 상태 초기화 로직 추가

### DIFF
--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -307,6 +307,10 @@ fun MainApp(
 
 
                     if (currentRoute == route) {
+                        if (item == LinkuNavigationItem.FILE) {
+                            // MainApp 범위 상태는 라우트 재생성 후에도 유지되므로 카테고리 루트로 되돌린다.
+                            folderStateViewModel.resetSharedFolderState()
+                        }
                         // 같은 탭 재선택: 내부 스택 리셋
                         navigator.navigate(route) {
                             // 해당 탭 루트까지 모두 제거하고


### PR DESCRIPTION
## 📝 설명
> 해당 PR이 진행한 사항을 자세히 적어주세요.


## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> 해당 PR과 관련된 이슈 번호를 적어주세요.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 현재 열려 있는 파일 탭을 다시 선택하면 공유 폴더 상태가 초기화됩니다.
  * 기존 탭 스택 초기화 및 동일 화면 재진입 동작이 정상적으로 수행됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->