### PR TITLE
♻️ refactor(file): 링크 카드 표시 구조 정리

### DIFF
--- a/feature/file/src/main/java/com/linku/file/ui/content/ClassifiedLinksGrid.kt
+++ b/feature/file/src/main/java/com/linku/file/ui/content/ClassifiedLinksGrid.kt
@@ -22,7 +22,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.text.font.FontWeight
@@ -37,6 +36,7 @@ import com.linku.design.theme.LinkuPreview
 import com.linku.design.theme.linkuColors
 import com.linku.file.R
 import com.linku.file.ui.item.LinkItemLayout
+import com.linku.file.ui.item.items.EmptyLinkItemLayout
 
 /**
  * 링크 카드 행 사이에 적용되는 기본 세로 간격(dp)입니다.
@@ -219,14 +219,8 @@ private fun AddLinkItem(
         modifier = modifier,
         contentAlignment = Alignment.TopCenter
     ) {
-        /** 실제 링크 카드와 같은 형태의 placeholder를 배경으로 사용합니다. */
-        Box(
-            modifier = Modifier.alpha(1f),
-        ) {
-            LinkItemLayout(
-                link = null
-            )
-        }
+        /** 실제 링크 카드와 같은 크기의 빈 링크 카드를 배경으로 사용합니다. */
+        EmptyLinkItemLayout()
 
         /** 링크 추가를 나타내는 아이콘을 카드 상단 기준 위치에 배치합니다. */
         Image(

--- a/feature/file/src/main/java/com/linku/file/ui/item/LinkItemLayout.kt
+++ b/feature/file/src/main/java/com/linku/file/ui/item/LinkItemLayout.kt
@@ -60,8 +60,10 @@ import coil3.request.fallback
 import coil3.request.placeholder
 import com.linku.core.model.LinkItemInfo
 import com.linku.design.theme.linkuColors
+import com.linku.design.theme.linkuFont
 import com.linku.file.R
 import com.linku.file.ui.theme.domainLogoPainterOrNull
+import com.linku.file.ui.theme.extractDomainHost
 
 /**
  * 링크 정보를 카드 형태로 표시합니다.
@@ -91,11 +93,17 @@ fun LinkItemLayout(
     /** 카드 배경, 텍스트, placeholder 색상을 가져오기 위한 LinkU 테마 색상 팔레트입니다. */
     val colors = MaterialTheme.linkuColors
 
+    /** 태그 텍스트에 적용할 LinkU 테마 폰트입니다. */
+    val font = MaterialTheme.linkuFont.font
+
     /** 링크가 없을 때는 태그 영역을 비워 placeholder 카드로 사용할 수 있게 합니다. */
     val tags = link?.tags ?: emptyList()
 
-    /** 링크 URL에서 도메인을 추출해 로컬 도메인 로고 painter를 찾습니다. */
-    val domainIcon = link?.let { domainLogoPainterOrNull(it.url) }
+    /** 링크 URL에서 하단에 표시할 도메인을 추출합니다. */
+    val domain = link?.url?.let(::extractDomainHost)
+
+    /** 추출한 도메인에 대응하는 로컬 도메인 로고 painter를 찾습니다. */
+    val domainIcon = domain?.let { domainLogoPainterOrNull(it) }
 
     /** 실제 링크 카드와 링크 추가용 placeholder 카드를 구분하는 플래그입니다. */
     val isNotAdder = link != null
@@ -191,6 +199,7 @@ fun LinkItemLayout(
                             .padding(horizontal = s(1.dp), vertical = s(2.dp)),
                         text = tag,
                         fontSize = ssp(12.sp),
+                        fontFamily = font,
                         fontWeight = FontWeight.Normal,
                         color = colors.gray[600],
                         textAlign = TextAlign.Center,
@@ -240,14 +249,18 @@ fun LinkItemLayout(
                     }
                 }
 
+                /** 빈 링크 카드에서는 제목, 태그, 도메인 영역을 구성하지 않습니다. */
+                if (!isNotAdder) return@Column
+
                 /** 썸네일과 제목 사이의 디자인 기준 간격입니다. */
                 Spacer(modifier = Modifier.height(s(10.dp)))
 
                 /** 링크 제목입니다. 긴 제목은 카드 너비 안에서 말줄임 처리합니다. */
                 Text(
                     modifier = Modifier.fillMaxWidth(),
-                    text = link?.title ?: "제목",
+                    text = link.title,
                     fontSize = ssp(15.sp),
+                    lineHeight = ssp(15.sp),
                     fontWeight = FontWeight(500),
                     color = colors.black,
                     maxLines = 1,
@@ -298,11 +311,12 @@ fun LinkItemLayout(
                         }
                     }
 
-                    /** 링크 URL 또는 placeholder 도메인 텍스트입니다. 긴 URL은 말줄임 처리합니다. */
+                    /** 추출한 도메인 또는 placeholder 텍스트입니다. 긴 도메인은 말줄임 처리합니다. */
                     Text(
                         modifier = Modifier.weight(1f),
-                        text = link?.url ?: "도메인",
+                        text = domain ?: "도메인",
                         fontSize = ssp(12.sp),
+                        lineHeight = ssp(12.sp),
                         fontWeight = FontWeight.Bold,
                         color = colors.gray[800],
                         maxLines = 1,

--- a/feature/file/src/main/java/com/linku/file/ui/item/items/EmptyLinkItemLayout.kt
+++ b/feature/file/src/main/java/com/linku/file/ui/item/items/EmptyLinkItemLayout.kt
@@ -1,0 +1,23 @@
+package com.linku.file.ui.item.items
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.linku.file.ui.item.LinkItemLayout
+
+/**
+ * 링크 추가 셀의 배경으로 사용하는 빈 링크 카드입니다.
+ *
+ * [LinkItemLayout]의 반응형 크기와 placeholder 썸네일을 재사용하되, 제목과 태그 및
+ * 도메인 정보는 표시하지 않습니다. 클릭 동작은 이 컴포저블을 사용하는 상위 요소에서 처리합니다.
+ *
+ * @param modifier 카드의 외부 크기와 배치를 결정하는 [Modifier]입니다.
+ */
+@Composable
+fun EmptyLinkItemLayout(
+    modifier: Modifier = Modifier,
+) {
+    LinkItemLayout(
+        modifier = modifier,
+        link = null,
+    )
+}

--- a/feature/file/src/main/java/com/linku/file/ui/theme/Domain.kt
+++ b/feature/file/src/main/java/com/linku/file/ui/theme/Domain.kt
@@ -37,23 +37,33 @@ val domainLogoMap: Map<String, Int> = mapOf(
     "x.com"              to R.drawable.domain_x_logo,
 )
 
-// URL 또는 host 문자열에서 host 추출
-private fun extractHost(urlOrHost: String): String? {
-    if (!urlOrHost.contains("://")) {
-        val cleaned = urlOrHost.trim().lowercase()
-        return if (cleaned.contains('.')) cleaned else null
+/**
+ * URL 또는 호스트 문자열에서 경로와 쿼리를 제외한 소문자 호스트를 추출합니다.
+ *
+ * 스킴이 없는 URL도 일관되게 파싱할 수 있도록 HTTPS URL로 정규화합니다.
+ *
+ * @param urlOrHost 전체 URL 또는 호스트 문자열입니다.
+ * @return 추출한 호스트이며, 입력이 비어 있거나 올바르게 파싱되지 않으면 `null`입니다.
+ */
+internal fun extractDomainHost(urlOrHost: String): String? {
+    val trimmed = urlOrHost.trim()
+    if (trimmed.isEmpty()) return null
+
+    val normalized = when {
+        trimmed.startsWith("//") -> "https:$trimmed"
+        trimmed.contains("://") -> trimmed
+        else -> "https://$trimmed"
     }
-    return try {
-        URI(urlOrHost).host?.lowercase()
-    } catch (_: Exception) {
-        null
-    }
+
+    return runCatching { URI(normalized).host?.lowercase() }
+        .getOrNull()
+        ?.takeIf { it.isNotBlank() }
 }
 
 // URL → Painter 변환 함수
 @Composable
 fun domainLogoPainterOrNull(urlOrHost: String): Painter? {
-    val host = extractHost(urlOrHost) ?: return null
+    val host = extractDomainHost(urlOrHost) ?: return null
 
     // 1) 정확 매칭
     domainLogoMap[host]?.let {

--- a/feature/file/src/test/java/com/linku/file/ExampleUnitTest.kt
+++ b/feature/file/src/test/java/com/linku/file/ExampleUnitTest.kt
@@ -1,12 +1,7 @@
-<<<<<<<< HEAD:feature/file/src/test/java/com/linku/file/ExampleUnitTest.kt
 package com.linku.file
-========
-package com.linku.data
->>>>>>>> fd1304faab6b86e04c17e31a0786ce151290d292:data/src/test/java/com/linku/data/ExampleUnitTest.kt
 
+import org.junit.Assert.assertEquals
 import org.junit.Test
-
-import org.junit.Assert.*
 
 /**
  * Example local unit test, which will execute on the development machine (host).

--- a/feature/file/src/test/java/com/linku/file/ui/theme/DomainTest.kt
+++ b/feature/file/src/test/java/com/linku/file/ui/theme/DomainTest.kt
@@ -1,0 +1,38 @@
+package com.linku.file.ui.theme
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class DomainTest {
+
+    @Test
+    fun `스킴이 있는 URL에서 소문자 호스트를 추출한다`() {
+        assertEquals(
+            "www.github.com",
+            extractDomainHost("HTTPS://WWW.GITHUB.COM/openai/codex?tab=readme"),
+        )
+    }
+
+    @Test
+    fun `스킴이 없는 URL에서도 경로와 포트를 제외한다`() {
+        assertEquals(
+            "blog.naver.com",
+            extractDomainHost("blog.naver.com:443/example/path?query=value"),
+        )
+    }
+
+    @Test
+    fun `스킴 상대 URL과 앞뒤 공백을 처리한다`() {
+        assertEquals(
+            "namu.wiki",
+            extractDomainHost("  //namu.wiki/w/LinkU  "),
+        )
+    }
+
+    @Test
+    fun `비어 있거나 올바르지 않은 URL은 null을 반환한다`() {
+        assertNull(extractDomainHost("   "))
+        assertNull(extractDomainHost("not a domain"))
+    }
+}


### PR DESCRIPTION
## 📝 설명
> 링크 카드의 반응형 표시와 링크 추가 빈 상태를 정리합니다.

- 링크 카드 제목과 도메인 줄 높이를 카드 크기에 맞춰 적용하고, 태그에 LinkU 테마 폰트를 적용했습니다.
- 전체 URL 대신 경로·쿼리·포트를 제거한 도메인 호스트를 카드 하단과 도메인 로고 조회에 공통으로 사용합니다.
- `EmptyLinkItemLayout`을 추가하고 링크 추가 셀에서 제목·태그·도메인을 구성하지 않도록 분리했습니다.
- URL 스킴 유무, 경로·포트, 공백 및 잘못된 입력을 검증하는 도메인 추출 단위 테스트를 추가했습니다.
- 단위 테스트 컴파일을 막던 `ExampleUnitTest` 병합 충돌 표식을 제거했습니다.

기존에는 `AddLinkItem`이 `LinkItemLayout(link = null)`을 직접 재사용해 fallback 제목과 도메인 영역까지 표시했고, 카드 하단에는 원본 URL 전체를 출력하고 있었습니다.

## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [x] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [x] 주석 추가 및 수정
- [ ] 문서 수정
- [x] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 🧪 검증
- `.\gradlew.bat :feature:file:compileDebugKotlin` — 성공
- `.\gradlew.bat :feature:file:testDebugUnitTest --tests "com.linku.file.ui.theme.DomainTest"` — 4개 통과
- `git diff --check` — 통과(CRLF 변환 안내만 발생)

## 📎 관련 이슈 번호
> 관련 이슈 없음


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **새 기능**
  - 링크 카드에 호스트 도메인명과 해당 도메인의 로고를 표시합니다.
  - 링크 추가 시 제목이나 메타정보 없이 깔끔한 빈 카드가 표시됩니다.
  - 태그에 LinkU 테마 글꼴이 적용됩니다.

- **버그 수정**
  - 다양한 형식의 URL에서 도메인을 보다 정확하게 인식합니다.
  - 공백, 스킴 누락, 포트·경로·쿼리가 포함된 URL도 안정적으로 처리합니다.
  - 비어 있거나 잘못된 URL은 오류 없이 처리됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->