### PR TITLE
fix: 큐레이션 탭 선택 시 바텀바 아이콘 미반영 버그 수정

### DIFF
--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -605,9 +605,6 @@ fun MainApp(
                             onNavigateToLinkDetail = { linkuId ->
                                 navigator.navigate("savelinkresult/$linkuId")
                             },
-                            onNavigateToCuration = {
-                                navigator.navigate("curation_card1")
-                            },
                             onNavigateToAlarm = {
                                 navigator.navigate(NavigationRoute.Alarm.route)
                             }

--- a/app/src/main/java/com/linku/MainApp.kt
+++ b/app/src/main/java/com/linku/MainApp.kt
@@ -187,7 +187,7 @@ fun MainApp(
 
     LaunchedEffect(currentRoute) {
         if (currentRoute == NavigationRoute.Home.route ||
-            currentRoute == "curation_list"
+            currentRoute == NavigationRoute.Curation.route
         ) {
             viewModel.fetchNickname()
         }

--- a/app/src/main/java/com/linku/navigation/BackHandlers.kt
+++ b/app/src/main/java/com/linku/navigation/BackHandlers.kt
@@ -28,7 +28,7 @@ fun DoubleBackToExitIfTop(navigator: NavController) {
     val isMainTab = when {
         route.startsWith("home") -> true
         route.startsWith("file") -> true
-        route.startsWith("curation") || route == "curation_graph" -> true
+        route.startsWith("curation") -> true
         route.startsWith("mypage") -> true
         else -> false
     }

--- a/feature/curation/src/main/java/com/linku/curation/navigation/CurationGraph.kt
+++ b/feature/curation/src/main/java/com/linku/curation/navigation/CurationGraph.kt
@@ -7,7 +7,6 @@ import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavHostController
 import androidx.navigation.NavType
 import androidx.navigation.compose.composable
-import androidx.navigation.compose.navigation
 import androidx.navigation.navArgument
 import com.linku.curation.ui.screen.CurationKeywordDetailScreen
 import com.linku.curation.ui.screen.CurationKeywordLinksScreen
@@ -38,108 +37,106 @@ fun NavGraphBuilder.curationGraph(
         }
     }
 
-    navigation(
-        startDestination = "curation_list",
-        route = "curation"
+    // 큐레이션 탭 루트 라우트는 다른 탭(home/file/my_page)과 동일하게 "curation" 그대로 사용하고,
+    // 하위 화면은 "curation/..." 접두사를 붙여 MainApp의 isTabRoute("curation" 기준)와
+    // DoubleBackToExitIfTop의 탭 판정 로직에 별도 처리 없이 그대로 매칭되도록 한다.
+    composable("curation") {
+        showNavBar(true)
+        // 상태바/내비게이션 바는 MainScreen(app 모듈)에서 공통으로 흰색 처리함.
+        val viewModel = hiltViewModel<CurationViewModel>()
+
+        CurationScreen(
+            nickname = nickname,
+            viewModel = viewModel,
+            onMonthlyDetailClick = { month, curationId ->
+                navigator.navigate("curation/detail/$month/$curationId")
+            },
+            onKeywordDetailClick = { month -> navigator.navigate("curation/card2/$month") },
+            onRemindClick = { navigator.navigate("curation/card3") },
+            onCurationHistoryClick = { year -> navigator.navigate("curation/monthly/$year") }
+        )
+    }
+
+    composable(
+        route = "curation/detail/{month}/{curationId}",
+        arguments = listOf(
+            navArgument("month") { type = NavType.StringType },
+            navArgument("curationId") { type = NavType.LongType }
+        )
     ) {
-        composable("curation_list") {
-            showNavBar(true)
-            // 상태바/내비게이션 바는 MainScreen(app 모듈)에서 공통으로 흰색 처리함.
-            val viewModel = hiltViewModel<CurationViewModel>()
+        showNavBar(false)
+        val viewModel = hiltViewModel<CurationDetailViewModel>()
 
-            CurationScreen(
-                nickname = nickname,
-                viewModel = viewModel,
-                onMonthlyDetailClick = { month, curationId ->
-                    navigator.navigate("curation_detail/$month/$curationId")
-                },
-                onKeywordDetailClick = { month -> navigator.navigate("curation_card2/$month") },
-                onRemindClick = { navigator.navigate("curation_card3") },
-                onCurationHistoryClick = { year -> navigator.navigate("curation_monthly/$year") }
-            )
-        }
+        CurationMonthlyDetailScreen(
+            viewModel = viewModel,
+            onBack = { navigator.popBackStack() },
+            onGoHome = goHome,
+            onNavigateToLinkDetail = { linkId -> navigator.navigate("savelinkresult/$linkId") }
+        )
+    }
 
-        composable(
-            route = "curation_detail/{month}/{curationId}",
-            arguments = listOf(
-                navArgument("month") { type = NavType.StringType },
-                navArgument("curationId") { type = NavType.LongType }
-            )
-        ) {
-            showNavBar(false)
-            val viewModel = hiltViewModel<CurationDetailViewModel>()
+    composable(
+        route = "curation/card2/{month}",
+        arguments = listOf(navArgument("month") { type = NavType.StringType })
+    ) { backStackEntry ->
+        showNavBar(false)
+        val month = backStackEntry.arguments?.getString("month").orEmpty()
+        val viewModel = hiltViewModel<CurationKeywordViewModel>()
 
-            CurationMonthlyDetailScreen(
-                viewModel = viewModel,
-                onBack = { navigator.popBackStack() },
-                onGoHome = goHome,
-                onNavigateToLinkDetail = { linkId -> navigator.navigate("savelinkresult/$linkId") }
-            )
-        }
+        CurationKeywordDetailScreen(
+            nickname = nickname,
+            month = month,
+            viewModel = viewModel,
+            onBack = { navigator.popBackStack() },
+            onNavigateToSaveLink = onNavigateToSaveLink,
+            onKeywordClick = { keyword ->
+                navigator.navigate("curation/keyword_links/${Uri.encode(keyword)}")
+            }
+        )
+    }
 
-        composable(
-            route = "curation_card2/{month}",
-            arguments = listOf(navArgument("month") { type = NavType.StringType })
-        ) { backStackEntry ->
-            showNavBar(false)
-            val month = backStackEntry.arguments?.getString("month").orEmpty()
-            val viewModel = hiltViewModel<CurationKeywordViewModel>()
+    composable(
+        route = "curation/keyword_links/{keyword}",
+        arguments = listOf(navArgument("keyword") { type = NavType.StringType })
+    ) { backStackEntry ->
+        showNavBar(false)
+        val keyword = backStackEntry.arguments?.getString("keyword")
+            ?.let { Uri.decode(it) }
+            .orEmpty()
 
-            CurationKeywordDetailScreen(
-                nickname = nickname,
-                month = month,
-                viewModel = viewModel,
-                onBack = { navigator.popBackStack() },
-                onNavigateToSaveLink = onNavigateToSaveLink,
-                onKeywordClick = { keyword ->
-                    navigator.navigate("curation_keyword_links/${Uri.encode(keyword)}")
-                }
-            )
-        }
+        CurationKeywordLinksScreen(
+            keyword = keyword,
+            nickname = nickname,
+            onBack = { navigator.popBackStack() }
+        )
+    }
 
-        composable(
-            route = "curation_keyword_links/{keyword}",
-            arguments = listOf(navArgument("keyword") { type = NavType.StringType })
-        ) { backStackEntry ->
-            showNavBar(false)
-            val keyword = backStackEntry.arguments?.getString("keyword")
-                ?.let { Uri.decode(it) }
-                .orEmpty()
+    composable("curation/card3") {
+        showNavBar(false)
+        val viewModel = hiltViewModel<CurationRemindViewModel>()
 
-            CurationKeywordLinksScreen(
-                keyword = keyword,
-                nickname = nickname,
-                onBack = { navigator.popBackStack() }
-            )
-        }
+        CurationRemindScreen(
+            viewModel = viewModel,
+            onBack = { navigator.popBackStack() },
+            onNavigateToLinkDetail = { linkId -> navigator.navigate("savelinkresult/$linkId") }
+        )
+    }
 
-        composable("curation_card3") {
-            showNavBar(false)
-            val viewModel = hiltViewModel<CurationRemindViewModel>()
+    composable(
+        route = "curation/monthly/{year}",
+        arguments = listOf(navArgument("year") { type = NavType.IntType })
+    ) { backStackEntry ->
+        showNavBar(false)
+        val year = backStackEntry.arguments?.getInt("year") ?: 0
+        val viewModel = hiltViewModel<CurationHistoryViewModel>()
 
-            CurationRemindScreen(
-                viewModel = viewModel,
-                onBack = { navigator.popBackStack() },
-                onNavigateToLinkDetail = { linkId -> navigator.navigate("savelinkresult/$linkId") }
-            )
-        }
-
-        composable(
-            route = "curation_monthly/{year}",
-            arguments = listOf(navArgument("year") { type = NavType.IntType })
-        ) { backStackEntry ->
-            showNavBar(false)
-            val year = backStackEntry.arguments?.getInt("year") ?: 0
-            val viewModel = hiltViewModel<CurationHistoryViewModel>()
-
-            MonthlyCurationScreen(
-                year = year,
-                viewModel = viewModel,
-                onBackClick = { navigator.popBackStack() },
-                onMonthClick = { month, curationId ->
-                    navigator.navigate("curation_detail/$month/$curationId")
-                }
-            )
-        }
+        MonthlyCurationScreen(
+            year = year,
+            viewModel = viewModel,
+            onBackClick = { navigator.popBackStack() },
+            onMonthClick = { month, curationId ->
+                navigator.navigate("curation/detail/$month/$curationId")
+            }
+        )
     }
 }

--- a/feature/home/src/main/java/com/linku/home/HomeApp.kt
+++ b/feature/home/src/main/java/com/linku/home/HomeApp.kt
@@ -21,7 +21,6 @@ fun HomeApp(
     onNavigateToSetting: () -> Unit,
     onNavigateToSaveLink: (String) -> Unit,
     onNavigateToLinkDetail: (Long) -> Unit,
-    onNavigateToCuration: () -> Unit,
     onNavigateToAlarm: () -> Unit,
     searchUiState: SearchBarUiState,
     searchResults: Flow<PagingData<SearchResultItem>>,


### PR DESCRIPTION
## 📝 설명
큐레이션 화면이 중첩 navigation 그래프로 등록되어 실제 destination route가
"curation_list"였던 반면, 바텀바의 탭 선택 판정 로직(isTabRoute)은
"curation"과 문자열 비교를 하고 있어 큐레이션 탭을 눌러도 선택 상태로
반영되지 않는 문제가 있었음.

큐레이션 그래프를 홈/파일/마이페이지와 동일한 평탄한(flat) composable
구조로 변경하고, 탭 루트 라우트를 "curation"으로, 하위 화면들은
"curation/..." 접두사로 통일하여 기존 탭 판정 로직에  그대로 매칭되도록 함.

## ✔️ PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [ ] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [ ] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [ ] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## 📎 관련 이슈 번호
> #267 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 큐레이션 화면의 탐색 경로를 일관된 구조로 정리했습니다.
  * 큐레이션 상세, 키워드, 리마인드, 월별 화면으로 이동하는 기능을 기존과 동일하게 이용할 수 있습니다.
  * 홈 또는 큐레이션 진입 시 닉네임 조회가 정상적으로 수행됩니다.
  * 큐레이션 화면에서 네비게이션 바 표시와 화면별 이동 동작을 유지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->